### PR TITLE
Add Rulesy-managed macOS configuration and hostnames

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,13 +4,14 @@ Guidance for agents working in this dotfiles repo.
 
 ## Architecture
 
-Dof owns bootstrap, workspace selection, and feature execution. The only
-intentional dof declaration is the executable `features/default/apply` hook.
+Dof owns bootstrap, workspace selection, and feature execution. Intentional
+dof declarations live in `features/default/`, `features/hostname/`, and
+`features/macos-gui/`.
 
 This is a transitional architecture: `features/default/apply` installs GNU
-Stow when needed, copies `initial-files/`, and Stows `home/` into the
-target `$HOME`.
-Do not convert payload files to native dof ownership unless explicitly asked.
+Stow and Rulesy when needed, exposes Rulesy through `dof run`, copies
+`initial-files/`, and Stows `home/` into the target `$HOME`. Do not convert
+payload files to native dof ownership unless explicitly asked.
 
 The canonical checkout is `$HOME/.dof/workspace`. Files under `home/` map to
 the same relative path beneath `$HOME`; files under `initial-files/` are
@@ -22,8 +23,14 @@ copied as regular files.
   runs `dof apply`.
 - `features/default/apply` is the idempotent feature hook and underlying
   installer.
+- `features/hostname/apply` derives the hardware-based macOS hostname and runs
+  its local Rulesy configuration through `dof run rulesy`.
+- `features/macos-gui/apply` runs its local Rulesy configuration through
+  `dof run rulesy`. Its app rules append exact entries to `$HOME/.Brewfile`,
+  then reconcile it through Homebrew Bundle.
 - `verify.sh` simulates Stow and checks the special Codex config link.
-- `uninstall.sh` removes Stow-owned links and the exact managed Codex link.
+- `uninstall.sh` removes `home/` Stow-owned links and the exact managed Codex
+  link.
 
 Normal maintenance is:
 
@@ -32,7 +39,7 @@ git -C "$HOME/.dof/workspace" pull --ff-only
 "$HOME/.dof/bin/dof" apply
 ```
 
-Uninstall deliberately leaves initial files, backups, GNU Stow,
+Uninstall deliberately leaves initial files, backups, GNU Stow, Rulesy,
 `$HOME/.dof/bin/dof`, and the dof workspace/config in place.
 
 ## Stow and Codex Rules
@@ -51,9 +58,9 @@ use `stow --adopt`, delete unmanaged files, or use `dof clone --force`.
 
 ## Workspace Rules
 
-Dof only discovers features beneath `features/`. For this migration, only
-`features/default/` may contain dof declarations (`home/`, `snippets.yaml`, or
-an `apply` hook). Repository-level infrastructure directories are inert.
+Dof only discovers features beneath `features/`. The intentional features are
+`features/default/`, `features/hostname/`, and `features/macos-gui/`.
+Repository-level infrastructure directories are inert.
 
 Do not add secrets, tokens, or machine-local credentials to managed payloads.
 
@@ -62,7 +69,9 @@ Do not add secrets, tokens, or machine-local credentials to managed payloads.
 Run:
 
 ```sh
-bash -n install.sh features/default/apply uninstall.sh verify.sh tests/run.sh
+bash -n install.sh features/default/apply features/hostname/apply \
+  features/hostname/desired-hostname features/macos-gui/apply uninstall.sh \
+  verify.sh tests/run.sh
 dof lint .
 tests/run.sh --all
 ```
@@ -70,6 +79,7 @@ tests/run.sh --all
 The Docker tests use isolated temporary homes and local repository snapshots;
 they must never install into the real `$HOME`. They cover package-manager
 selection, bootstrap delegation, dof apply, Stow ownership, legacy handoff,
-backups, conflicts, verification, and uninstall behavior.
+backups, conflicts, Rulesy delegation, hostname derivation, macOS gating,
+verification, and uninstall behavior.
 
 If Docker is unavailable, state that clearly in the final message.

--- a/README.md
+++ b/README.md
@@ -5,3 +5,29 @@ Personal dotfiles orchestrated by [dof](https://github.com/notwillk/dof).
 The transitional `default` feature uses GNU Stow to link the existing `home/`
 payload and preserves the copied `initial-files/` behavior. Human-facing update
 and recovery notes are installed as `managed_by_dofiles.md`.
+
+The `macos-gui` feature uses Rulesy to install Homebrew, append its desired
+formula, casks, and App Store entries to `$HOME/.Brewfile`, and reconcile them
+through `brew bundle --global`. It keeps macOS screenshot storage pointed at
+`$HOME/Screenshots`. It also configures the upper Hot Corners to disable the
+screen saver, Command plus either lower corner to lock the screen, and
+Control-scroll to zoom the screen. Its rules skip on non-macOS systems;
+screenshot and Hot Corner rules also skip macOS releases older than 10.14.
+The Lock Screen rules turn the display off after 10 minutes of inactivity on
+battery and after 60 minutes on a power adapter.
+The Trackpad rules disable swiping between pages and the two-finger swipe from
+the right edge that opens Notification Center.
+The appearance rules keep the system in Dark mode and, on macOS 26 and newer,
+use the Clear icon and widget style.
+The menu bar clock always shows the date in digital style while hiding the
+weekday, AM/PM label, seconds, separator flashing, and time announcements.
+On macOS 26 and newer, Wi-Fi, battery, and weather remain visible; Focus,
+Screen Mirroring, Display, Sound, and Timer appear only while active; and
+Spotlight, Bluetooth, AirDrop, Fast User Switching, Text Input, Time Machine,
+Keyboard Brightness, and VPN remain hidden.
+
+The `hostname` feature derives `<machine-type>-<chip-type>-<year>` from the Mac
+family, Apple chip, and model year—for example, a 2024 MacBook Pro with an M4
+Pro becomes `mbp-m4p-2024`. It reconciles the computer, Bonjour, and network
+hostnames, requesting administrator authentication only when a name needs to
+change.

--- a/features/default/apply
+++ b/features/default/apply
@@ -72,11 +72,69 @@ DOTFILES_STATE_PATH="${HOME}/.dotfiles"
 BACKUP_PATH="${DOTFILES_STATE_PATH}/backups"
 CODEX_SOURCE_PATH="${DOTFILES_SOURCE_PATH}/.codex"
 CODEX_TARGET_PATH="${HOME}/.codex"
+RULESY_BIN="${HOME}/bin/rulesy"
+DOF_RULESY_BIN="${HOME}/.dof/bin/rulesy"
+RULESY_INSTALL_URL="https://raw.githubusercontent.com/notwillk/rulesy/main/scripts/install.sh"
 
 if [[ ! -d "${DOTFILES_SOURCE_PATH}" ]]; then
   log "Expected Stow package directory '${DOTFILES_SOURCE_PATH}' does not exist." >&2
   exit 1
 fi
+
+install_rulesy() {
+  if [[ -x "${RULESY_BIN}" ]]; then
+    log "Rulesy is installed: ${RULESY_BIN}"
+    return
+  fi
+
+  mkdir -p "${HOME}/bin"
+  log "Rulesy is not installed. Installing to ${RULESY_BIN}..."
+  curl -fsSL "${RULESY_INSTALL_URL}" | DEST="${HOME}/bin" bash
+
+  if [[ ! -x "${RULESY_BIN}" ]]; then
+    log "Rulesy installation completed without creating executable '${RULESY_BIN}'." >&2
+    exit 1
+  fi
+
+  log "Rulesy installed: ${RULESY_BIN}"
+}
+
+install_rulesy_for_dof() {
+  local wrapper_dir
+  local wrapper_tmp
+
+  wrapper_dir="$(dirname "${DOF_RULESY_BIN}")"
+  mkdir -p "${wrapper_dir}"
+  wrapper_tmp="$(mktemp "${wrapper_dir}/.rulesy.XXXXXX")"
+
+  if ! {
+    printf '%s\n' \
+      '#!/usr/bin/env bash' \
+      'set -euo pipefail' \
+      'exec "${HOME}/bin/rulesy" "$@"' >"${wrapper_tmp}" &&
+      chmod 0755 "${wrapper_tmp}"
+  }; then
+    rm -f "${wrapper_tmp}"
+    log "Could not create the Rulesy dof entrypoint." >&2
+    exit 1
+  fi
+
+  if [[ -e "${DOF_RULESY_BIN}" || -L "${DOF_RULESY_BIN}" ]]; then
+    if [[ -f "${DOF_RULESY_BIN}" && ! -L "${DOF_RULESY_BIN}" &&
+      -x "${DOF_RULESY_BIN}" ]] && cmp -s "${wrapper_tmp}" "${DOF_RULESY_BIN}"; then
+      rm -f "${wrapper_tmp}"
+      log "Rulesy dof entrypoint is installed: ${DOF_RULESY_BIN}"
+      return
+    fi
+
+    rm -f "${wrapper_tmp}"
+    log "Cannot install Rulesy dof entrypoint because '${DOF_RULESY_BIN}' already exists." >&2
+    exit 1
+  fi
+
+  mv "${wrapper_tmp}" "${DOF_RULESY_BIN}"
+  log "Installed Rulesy dof entrypoint: ${DOF_RULESY_BIN}"
+}
 
 backup_target() {
   local target_file="$1"
@@ -247,6 +305,9 @@ else
 
   log "GNU Stow installed: $(command -v stow)"
 fi
+
+install_rulesy
+install_rulesy_for_dof
 
 resolve_link_target() {
   local link_path="$1"

--- a/features/hostname/apply
+++ b/features/hostname/apply
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+FEATURE_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+export PATH="${HOME}/.dof/bin:${PATH}"
+
+dof run rulesy \
+  "--config=${FEATURE_ROOT}/rulesy.yaml" \
+  check \
+  --fix

--- a/features/hostname/desired-hostname
+++ b/features/hostname/desired-hostname
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+fail() {
+  printf '[hostname/desired-hostname] %s\n' "$*" >&2
+  exit 1
+}
+
+[[ "$(uname -s)" == "Darwin" ]] || fail "hostname derivation is supported only on macOS"
+
+marketing_name="$(
+  ioreg -l -r -c IOPlatformDevice 2>/dev/null |
+    awk -F '"' '/"product-name"[[:space:]]*=/ { print $4; exit }'
+)"
+[[ -n "${marketing_name}" ]] || fail "could not determine the Mac marketing model name"
+
+case "${marketing_name}" in
+  "MacBook Pro"*) machine_type="mbp" ;;
+  "MacBook Air"*) machine_type="mba" ;;
+  "MacBook"*) machine_type="mb" ;;
+  "iMac Pro"*) machine_type="imacp" ;;
+  "iMac"*) machine_type="imac" ;;
+  "Mac mini"*) machine_type="mm" ;;
+  "Mac Studio"*) machine_type="ms" ;;
+  "Mac Pro"*) machine_type="mp" ;;
+  *) fail "unsupported Mac model: ${marketing_name}" ;;
+esac
+
+hardware_profile="$(system_profiler SPHardwareDataType 2>/dev/null)"
+chip_name="$(
+  awk -F ': ' '/^[[:space:]]*Chip:/ { print $2; exit }' <<<"${hardware_profile}"
+)"
+
+if [[ ! "${chip_name}" =~ ^Apple[[:space:]]+M([0-9]+)([[:space:]]+(Pro|Max|Ultra))?$ ]]; then
+  fail "unsupported chip description: ${chip_name:-unknown}"
+fi
+
+chip_type="m${BASH_REMATCH[1]}"
+case "${BASH_REMATCH[3]:-}" in
+  Pro) chip_type+="p" ;;
+  Max) chip_type+="m" ;;
+  Ultra) chip_type+="u" ;;
+esac
+
+if [[ ! "${marketing_name}" =~ (^|[^0-9])((19|20)[0-9]{2})([^0-9]|$) ]]; then
+  fail "could not determine the model year from: ${marketing_name}"
+fi
+model_year="${BASH_REMATCH[2]}"
+
+printf '%s-%s-%s\n' "${machine_type}" "${chip_type}" "${model_year}"

--- a/features/hostname/rulesy.yaml
+++ b/features/hostname/rulesy.yaml
@@ -2,11 +2,13 @@ rules:
   - name: macOS hostname follows the hardware naming convention
     skip-if: '[[ "$(uname -s)" != "Darwin" ]]'
     check: |
+      set -e
       desired="$(./desired-hostname)"
       test "$(scutil --get ComputerName 2>/dev/null)" = "${desired}"
       test "$(scutil --get LocalHostName 2>/dev/null)" = "${desired}"
       test "$(scutil --get HostName 2>/dev/null)" = "${desired}"
     interactive-fix: |
+      set -e
       desired="$(./desired-hostname)"
       sudo -v
       sudo scutil --set ComputerName "${desired}"

--- a/features/hostname/rulesy.yaml
+++ b/features/hostname/rulesy.yaml
@@ -1,0 +1,14 @@
+rules:
+  - name: macOS hostname follows the hardware naming convention
+    skip-if: '[[ "$(uname -s)" != "Darwin" ]]'
+    check: |
+      desired="$(./desired-hostname)"
+      test "$(scutil --get ComputerName 2>/dev/null)" = "${desired}"
+      test "$(scutil --get LocalHostName 2>/dev/null)" = "${desired}"
+      test "$(scutil --get HostName 2>/dev/null)" = "${desired}"
+    interactive-fix: |
+      desired="$(./desired-hostname)"
+      sudo -v
+      sudo scutil --set ComputerName "${desired}"
+      sudo scutil --set LocalHostName "${desired}"
+      sudo scutil --set HostName "${desired}"

--- a/features/macos-gui/accessibility.rulesy.yaml
+++ b/features/macos-gui/accessibility.rulesy.yaml
@@ -1,0 +1,9 @@
+rules:
+  - name: Control-scroll screen zoom is enabled
+    skip-if: '[[ "$(uname -s)" != "Darwin" ]]'
+    check: |
+      test "$(defaults read com.apple.universalaccess closeViewScrollWheelToggle 2>/dev/null)" = 1
+      test "$(defaults read com.apple.universalaccess HIDScrollZoomModifierMask 2>/dev/null)" = 262144
+    fix: |
+      defaults write com.apple.universalaccess closeViewScrollWheelToggle -bool true
+      defaults write com.apple.universalaccess HIDScrollZoomModifierMask -int 262144

--- a/features/macos-gui/accessibility.rulesy.yaml
+++ b/features/macos-gui/accessibility.rulesy.yaml
@@ -2,6 +2,7 @@ rules:
   - name: Control-scroll screen zoom is enabled
     skip-if: '[[ "$(uname -s)" != "Darwin" ]]'
     check: |
+      set -e
       test "$(defaults read com.apple.universalaccess closeViewScrollWheelToggle 2>/dev/null)" = 1
       test "$(defaults read com.apple.universalaccess HIDScrollZoomModifierMask 2>/dev/null)" = 262144
     fix: |

--- a/features/macos-gui/appearance.rulesy.yaml
+++ b/features/macos-gui/appearance.rulesy.yaml
@@ -1,0 +1,26 @@
+rules:
+  # macOS 10.14 (Mojave) introduced system-wide Dark appearance.
+  - name: System appearance is always Dark
+    skip-if: |
+      [[ "$(uname -s)" != "Darwin" ]] && exit 0
+      version="$(sw_vers -productVersion 2>/dev/null)" || exit 0
+      IFS=. read -r major minor _ <<<"${version}"
+      [[ "${major:-}" =~ ^[0-9]+$ && "${minor:-}" =~ ^[0-9]+$ ]] || exit 0
+      (( major < 10 || (major == 10 && minor < 14) ))
+    check: |
+      test "$(defaults read NSGlobalDomain AppleInterfaceStyle 2>/dev/null)" = Dark
+      test "$(defaults read NSGlobalDomain AppleInterfaceStyleSwitchesAutomatically 2>/dev/null || true)" != 1
+    fix: |
+      defaults delete NSGlobalDomain AppleInterfaceStyleSwitchesAutomatically >/dev/null 2>&1 || true
+      defaults write NSGlobalDomain AppleInterfaceStyle -string Dark
+
+  # macOS 26 (Tahoe) introduced the Clear icon and widget style.
+  - name: Icon and widget style is Clear
+    skip-if: |
+      [[ "$(uname -s)" != "Darwin" ]] && exit 0
+      version="$(sw_vers -productVersion 2>/dev/null)" || exit 0
+      IFS=. read -r major _ <<<"${version}"
+      [[ "${major:-}" =~ ^[0-9]+$ ]] || exit 0
+      (( major < 26 ))
+    check: test "$(defaults read NSGlobalDomain AppleIconAppearanceTheme 2>/dev/null)" = ClearAutomatic
+    fix: defaults write NSGlobalDomain AppleIconAppearanceTheme -string ClearAutomatic

--- a/features/macos-gui/appearance.rulesy.yaml
+++ b/features/macos-gui/appearance.rulesy.yaml
@@ -8,6 +8,7 @@ rules:
       [[ "${major:-}" =~ ^[0-9]+$ && "${minor:-}" =~ ^[0-9]+$ ]] || exit 0
       (( major < 10 || (major == 10 && minor < 14) ))
     check: |
+      set -e
       test "$(defaults read NSGlobalDomain AppleInterfaceStyle 2>/dev/null)" = Dark
       test "$(defaults read NSGlobalDomain AppleInterfaceStyleSwitchesAutomatically 2>/dev/null || true)" != 1
     fix: |

--- a/features/macos-gui/apply
+++ b/features/macos-gui/apply
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+FEATURE_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+export PATH="${HOME}/.dof/bin:${PATH}"
+
+dof run rulesy \
+  "--config=${FEATURE_ROOT}/rulesy.yaml" \
+  check \
+  --fix \
+  --non-interactive

--- a/features/macos-gui/apps.rulesy.yaml
+++ b/features/macos-gui/apps.rulesy.yaml
@@ -1,0 +1,65 @@
+rules:
+  - name: Homebrew is installed
+    skip-if: '[[ "$(uname -s)" != "Darwin" ]]'
+    check: command -v brew >/dev/null 2>&1 || test -x /opt/homebrew/bin/brew || test -x /usr/local/bin/brew
+    fix: /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
+
+  - name: Global Brewfile contains the mas formula
+    skip-if: '[[ "$(uname -s)" != "Darwin" ]]'
+    check: grep -Fxq 'brew "mas"' "${HOME}/.Brewfile" 2>/dev/null
+    fix: printf '%s\n' 'brew "mas"' >>"${HOME}/.Brewfile"
+
+  - name: Global Brewfile contains the 1Password cask
+    skip-if: '[[ "$(uname -s)" != "Darwin" ]]'
+    check: grep -Fxq 'cask "1password"' "${HOME}/.Brewfile" 2>/dev/null
+    fix: printf '%s\n' 'cask "1password"' >>"${HOME}/.Brewfile"
+
+  - name: Global Brewfile contains the ChatGPT cask
+    skip-if: '[[ "$(uname -s)" != "Darwin" ]]'
+    check: grep -Fxq 'cask "chatgpt"' "${HOME}/.Brewfile" 2>/dev/null
+    fix: printf '%s\n' 'cask "chatgpt"' >>"${HOME}/.Brewfile"
+
+  - name: Global Brewfile contains the Brave Browser cask
+    skip-if: '[[ "$(uname -s)" != "Darwin" ]]'
+    check: grep -Fxq 'cask "brave-browser"' "${HOME}/.Brewfile" 2>/dev/null
+    fix: printf '%s\n' 'cask "brave-browser"' >>"${HOME}/.Brewfile"
+
+  - name: Global Brewfile contains the Lungo App Store app
+    skip-if: '[[ "$(uname -s)" != "Darwin" ]]'
+    check: |
+      grep -Fxq 'mas "Lungo", id: 1263070803' "${HOME}/.Brewfile" 2>/dev/null
+    fix: |
+      printf '%s\n' 'mas "Lungo", id: 1263070803' >>"${HOME}/.Brewfile"
+
+  - name: Global Brewfile contains the PIA VPN App Store app
+    skip-if: '[[ "$(uname -s)" != "Darwin" ]]'
+    check: |
+      grep -Fxq 'mas "PIA VPN", id: 955626407' "${HOME}/.Brewfile" 2>/dev/null
+    fix: |
+      printf '%s\n' 'mas "PIA VPN", id: 955626407' >>"${HOME}/.Brewfile"
+
+  - name: Global Brewfile contains the Tailscale App Store app
+    skip-if: '[[ "$(uname -s)" != "Darwin" ]]'
+    check: |
+      grep -Fxq 'mas "Tailscale", id: 1475387142' "${HOME}/.Brewfile" 2>/dev/null
+    fix: |
+      printf '%s\n' 'mas "Tailscale", id: 1475387142' >>"${HOME}/.Brewfile"
+
+  - name: Brewfile applications are installed
+    skip-if: '[[ "$(uname -s)" != "Darwin" ]]'
+    check: |
+      brew_bin="$(command -v brew || true)"
+      if [[ -z "${brew_bin}" && -x /opt/homebrew/bin/brew ]]; then
+        brew_bin=/opt/homebrew/bin/brew
+      elif [[ -z "${brew_bin}" && -x /usr/local/bin/brew ]]; then
+        brew_bin=/usr/local/bin/brew
+      fi
+      [[ -n "${brew_bin}" ]] && "${brew_bin}" bundle check --global
+    fix: |
+      brew_bin="$(command -v brew || true)"
+      if [[ -z "${brew_bin}" && -x /opt/homebrew/bin/brew ]]; then
+        brew_bin=/opt/homebrew/bin/brew
+      elif [[ -z "${brew_bin}" && -x /usr/local/bin/brew ]]; then
+        brew_bin=/usr/local/bin/brew
+      fi
+      [[ -n "${brew_bin}" ]] && "${brew_bin}" bundle --global

--- a/features/macos-gui/hot-corners.rulesy.yaml
+++ b/features/macos-gui/hot-corners.rulesy.yaml
@@ -1,0 +1,28 @@
+rules:
+  # macOS 10.14 (Mojave) supports the current Hot Corners workflow.
+  - name: Hot corners have the intended actions
+    skip-if: |
+      [[ "$(uname -s)" != "Darwin" ]] && exit 0
+      version="$(sw_vers -productVersion 2>/dev/null)" || exit 0
+      IFS=. read -r major minor _ <<<"${version}"
+      [[ "${major:-}" =~ ^[0-9]+$ && "${minor:-}" =~ ^[0-9]+$ ]] || exit 0
+      (( major < 10 || (major == 10 && minor < 14) ))
+    check: |
+      test "$(defaults read com.apple.dock wvous-tl-corner 2>/dev/null)" = 6
+      test "$(defaults read com.apple.dock wvous-tl-modifier 2>/dev/null)" = 0
+      test "$(defaults read com.apple.dock wvous-tr-corner 2>/dev/null)" = 6
+      test "$(defaults read com.apple.dock wvous-tr-modifier 2>/dev/null)" = 0
+      test "$(defaults read com.apple.dock wvous-bl-corner 2>/dev/null)" = 13
+      test "$(defaults read com.apple.dock wvous-bl-modifier 2>/dev/null)" = 1048576
+      test "$(defaults read com.apple.dock wvous-br-corner 2>/dev/null)" = 13
+      test "$(defaults read com.apple.dock wvous-br-modifier 2>/dev/null)" = 1048576
+    fix: |
+      defaults write com.apple.dock wvous-tl-corner -int 6
+      defaults write com.apple.dock wvous-tl-modifier -int 0
+      defaults write com.apple.dock wvous-tr-corner -int 6
+      defaults write com.apple.dock wvous-tr-modifier -int 0
+      defaults write com.apple.dock wvous-bl-corner -int 13
+      defaults write com.apple.dock wvous-bl-modifier -int 1048576
+      defaults write com.apple.dock wvous-br-corner -int 13
+      defaults write com.apple.dock wvous-br-modifier -int 1048576
+      killall Dock

--- a/features/macos-gui/hot-corners.rulesy.yaml
+++ b/features/macos-gui/hot-corners.rulesy.yaml
@@ -8,6 +8,7 @@ rules:
       [[ "${major:-}" =~ ^[0-9]+$ && "${minor:-}" =~ ^[0-9]+$ ]] || exit 0
       (( major < 10 || (major == 10 && minor < 14) ))
     check: |
+      set -e
       test "$(defaults read com.apple.dock wvous-tl-corner 2>/dev/null)" = 6
       test "$(defaults read com.apple.dock wvous-tl-modifier 2>/dev/null)" = 0
       test "$(defaults read com.apple.dock wvous-tr-corner 2>/dev/null)" = 6
@@ -25,4 +26,4 @@ rules:
       defaults write com.apple.dock wvous-bl-modifier -int 1048576
       defaults write com.apple.dock wvous-br-corner -int 13
       defaults write com.apple.dock wvous-br-modifier -int 1048576
-      killall Dock
+      killall Dock >/dev/null 2>&1 || true

--- a/features/macos-gui/lock-screen.rulesy.yaml
+++ b/features/macos-gui/lock-screen.rulesy.yaml
@@ -1,0 +1,32 @@
+rules:
+  - name: Display turns off after 10 minutes on battery
+    skip-if: |
+      [[ "$(uname -s)" != "Darwin" ]] && exit 0
+      ! pmset -g custom 2>/dev/null | grep -q '^[[:space:]]*Battery Power:'
+    check: |
+      set -e
+      timeout="$(
+        pmset -g custom 2>/dev/null |
+          awk '
+            /^[[:space:]]*Battery Power:/ { active = 1; next }
+            /^[[:space:]]*(AC|UPS) Power:/ { active = 0 }
+            active && $1 == "displaysleep" { print $2; exit }
+          '
+      )"
+      test "${timeout}" = 10
+    fix: sudo pmset -b displaysleep 10
+
+  - name: Display turns off after 60 minutes on power adapter
+    skip-if: '[[ "$(uname -s)" != "Darwin" ]]'
+    check: |
+      set -e
+      timeout="$(
+        pmset -g custom 2>/dev/null |
+          awk '
+            /^[[:space:]]*AC Power:/ { active = 1; next }
+            /^[[:space:]]*(Battery|UPS) Power:/ { active = 0 }
+            active && $1 == "displaysleep" { print $2; exit }
+          '
+      )"
+      test "${timeout}" = 60
+    fix: sudo pmset -c displaysleep 60

--- a/features/macos-gui/menu-bar.rulesy.yaml
+++ b/features/macos-gui/menu-bar.rulesy.yaml
@@ -1,0 +1,152 @@
+rules:
+  # ShowDate uses 0=when space allows, 1=always, and 2=never on macOS 12.4+.
+  - name: Menu bar clock has the intended presentation
+    skip-if: |
+      [[ "$(uname -s)" != "Darwin" ]] && exit 0
+      version="$(sw_vers -productVersion 2>/dev/null)" || exit 0
+      IFS=. read -r major minor _ <<<"${version}"
+      [[ "${major:-}" =~ ^[0-9]+$ && "${minor:-}" =~ ^[0-9]+$ ]] || exit 0
+      (( major < 12 || (major == 12 && minor < 4) ))
+    check: |
+      set -e
+      test "$(defaults read com.apple.menuextra.clock ShowDayOfWeek 2>/dev/null)" = 0
+      test "$(defaults read com.apple.menuextra.clock ShowDate 2>/dev/null)" = 1
+      test "$(defaults read com.apple.menuextra.clock IsAnalog 2>/dev/null)" = 0
+      test "$(defaults read com.apple.menuextra.clock ShowAMPM 2>/dev/null)" = 0
+      test "$(defaults read com.apple.menuextra.clock FlashDateSeparators 2>/dev/null)" = 0
+      test "$(defaults read com.apple.menuextra.clock ShowSeconds 2>/dev/null)" = 0
+
+      menu_announcement="$(defaults read com.apple.menuextra.clock TimeAnnouncementsEnabled 2>/dev/null || true)"
+      test -z "${menu_announcement}" || test "${menu_announcement}" = 0
+
+      speech_announcement="$(
+        defaults read com.apple.speech.synthesis.general.prefs TimeAnnouncementPrefs 2>/dev/null |
+          awk -F '= ' '/TimeAnnouncementsEnabled/ { gsub(/;/, "", $2); print $2; exit }'
+      )"
+      test -z "${speech_announcement}" || test "${speech_announcement}" = 0
+    fix: |
+      set -e
+      defaults write com.apple.menuextra.clock ShowDayOfWeek -bool false
+      defaults write com.apple.menuextra.clock ShowDate -int 1
+      defaults write com.apple.menuextra.clock IsAnalog -bool false
+      defaults write com.apple.menuextra.clock ShowAMPM -bool false
+      defaults write com.apple.menuextra.clock FlashDateSeparators -bool false
+      defaults write com.apple.menuextra.clock ShowSeconds -bool false
+      defaults write com.apple.menuextra.clock TimeAnnouncementsEnabled -bool false
+      defaults write com.apple.speech.synthesis.general.prefs \
+        TimeAnnouncementPrefs -dict-add TimeAnnouncementsEnabled -bool false
+      killall SpeechSynthesisServer >/dev/null 2>&1 || true
+      killall ControlCenter >/dev/null 2>&1 || true
+
+  # macOS 26 (Tahoe) exposes this complete set in Menu Bar settings.
+  - name: Menu bar controls have the intended visibility
+    skip-if: |
+      [[ "$(uname -s)" != "Darwin" ]] && exit 0
+      version="$(sw_vers -productVersion 2>/dev/null)" || exit 0
+      IFS=. read -r major _ <<<"${version}"
+      [[ "${major:-}" =~ ^[0-9]+$ ]] || exit 0
+      (( major < 26 ))
+    check: |
+      set -e
+
+      is_false_or_unset() {
+        local value
+        value="$(defaults read "$1" "$2" 2>/dev/null || true)"
+        test -z "${value}" || test "${value}" = 0
+      }
+
+      is_hidden_module() {
+        local module="$1"
+        shift
+        local value
+        value="$(defaults -currentHost read com.apple.controlcenter "${module}" 2>/dev/null)"
+        [[ " $* " == *" ${value} "* ]]
+        is_false_or_unset com.apple.controlcenter "NSStatusItem Visible ${module}"
+      }
+
+      test "$(defaults -currentHost read com.apple.controlcenter WiFi 2>/dev/null)" = 2
+      test "$(defaults read com.apple.controlcenter 'NSStatusItem Visible WiFi' 2>/dev/null)" = 1
+      test "$(defaults read com.apple.controlcenter 'NSStatusItem Visible Battery' 2>/dev/null)" = 1
+      test "$(defaults -currentHost read com.apple.controlcenter Weather 2>/dev/null)" = 2
+      test "$(defaults read com.apple.controlcenter 'NSStatusItem Visible Weather' 2>/dev/null)" = 1
+
+      test "$(defaults -currentHost read com.apple.controlcenter FocusModes 2>/dev/null)" = 2
+      test "$(defaults -currentHost read com.apple.controlcenter ScreenMirroring 2>/dev/null)" = 2
+      test "$(defaults -currentHost read com.apple.controlcenter Display 2>/dev/null)" = 2
+      test "$(defaults -currentHost read com.apple.controlcenter Sound 2>/dev/null)" = 2
+      test "$(defaults -currentHost read com.apple.controlcenter Timer 2>/dev/null)" = 2
+
+      test "$(defaults -currentHost read com.apple.Spotlight MenuItemHidden 2>/dev/null)" = 1
+      is_false_or_unset com.apple.Spotlight 'NSStatusItem Visible Item-0'
+      is_hidden_module Bluetooth 24
+      is_hidden_module AirDrop 8
+      is_hidden_module UserSwitcher 8 9 12
+      is_hidden_module TextInput 8
+      is_hidden_module TimeMachine 8
+      is_hidden_module KeyboardBrightness 8 9 12
+      is_hidden_module VPN 8
+      is_false_or_unset com.apple.TextInputMenu visible
+      is_false_or_unset com.apple.systemuiserver \
+        'NSStatusItem Visible com.apple.menuextra.TimeMachine'
+      is_false_or_unset com.apple.systemuiserver \
+        'NSStatusItem Visible com.apple.menuextra.vpn'
+    fix: |
+      set -e
+
+      show_module() {
+        defaults -currentHost write com.apple.controlcenter "$1" -int 2
+        defaults write com.apple.controlcenter "NSStatusItem Visible $1" -bool true
+      }
+
+      hide_module() {
+        defaults -currentHost write com.apple.controlcenter "$1" -int "$2"
+        defaults write com.apple.controlcenter "NSStatusItem Visible $1" -bool false
+      }
+
+      hide_combined_module() {
+        local module="$1"
+        local current desired
+        current="$(defaults -currentHost read com.apple.controlcenter "${module}" 2>/dev/null || true)"
+        case "${current}" in
+          3|9) desired=9 ;;
+          6|12) desired=12 ;;
+          *) desired=8 ;;
+        esac
+        hide_module "${module}" "${desired}"
+      }
+
+      show_module WiFi
+
+      battery="$(defaults -currentHost read com.apple.controlcenter Battery 2>/dev/null || true)"
+      case "${battery}" in
+        3|9) battery=3 ;;
+        6|12) battery=6 ;;
+        *) battery=2 ;;
+      esac
+      defaults -currentHost write com.apple.controlcenter Battery -int "${battery}"
+      defaults write com.apple.controlcenter 'NSStatusItem Visible Battery' -bool true
+
+      show_module Weather
+      defaults -currentHost write com.apple.controlcenter FocusModes -int 2
+      defaults -currentHost write com.apple.controlcenter ScreenMirroring -int 2
+      defaults -currentHost write com.apple.controlcenter Display -int 2
+      defaults -currentHost write com.apple.controlcenter Sound -int 2
+      defaults -currentHost write com.apple.controlcenter Timer -int 2
+
+      defaults -currentHost write com.apple.Spotlight MenuItemHidden -bool true
+      defaults write com.apple.Spotlight 'NSStatusItem Visible Item-0' -bool false
+      hide_module Bluetooth 24
+      hide_module AirDrop 8
+      hide_combined_module UserSwitcher
+      hide_module TextInput 8
+      hide_module TimeMachine 8
+      hide_combined_module KeyboardBrightness
+      hide_module VPN 8
+      defaults write com.apple.TextInputMenu visible -bool false
+      defaults write com.apple.systemuiserver \
+        'NSStatusItem Visible com.apple.menuextra.TimeMachine' -bool false
+      defaults write com.apple.systemuiserver \
+        'NSStatusItem Visible com.apple.menuextra.vpn' -bool false
+
+      killall ControlCenter >/dev/null 2>&1 || true
+      killall SystemUIServer >/dev/null 2>&1 || true

--- a/features/macos-gui/rulesy.yaml
+++ b/features/macos-gui/rulesy.yaml
@@ -1,0 +1,9 @@
+rules:
+  - remote: accessibility.rulesy.yaml
+  - remote: appearance.rulesy.yaml
+  - remote: apps.rulesy.yaml
+  - remote: hot-corners.rulesy.yaml
+  - remote: lock-screen.rulesy.yaml
+  - remote: menu-bar.rulesy.yaml
+  - remote: screenshots.rulesy.yaml
+  - remote: trackpad.rulesy.yaml

--- a/features/macos-gui/screenshots.rulesy.yaml
+++ b/features/macos-gui/screenshots.rulesy.yaml
@@ -8,6 +8,7 @@ rules:
       [[ "${major:-}" =~ ^[0-9]+$ && "${minor:-}" =~ ^[0-9]+$ ]] || exit 0
       (( major < 10 || (major == 10 && minor < 14) ))
     check: |
+      set -e
       test -d "$HOME/Screenshots"
       test "$(defaults read com.apple.screencapture location 2>/dev/null)" = "$HOME/Screenshots"
     fix: |

--- a/features/macos-gui/screenshots.rulesy.yaml
+++ b/features/macos-gui/screenshots.rulesy.yaml
@@ -1,0 +1,15 @@
+rules:
+  # macOS 10.14 (Mojave) introduced Apple's supported save-location workflow.
+  - name: Screenshots save to ~/Screenshots
+    skip-if: |
+      [[ "$(uname -s)" != "Darwin" ]] && exit 0
+      version="$(sw_vers -productVersion 2>/dev/null)" || exit 0
+      IFS=. read -r major minor _ <<<"${version}"
+      [[ "${major:-}" =~ ^[0-9]+$ && "${minor:-}" =~ ^[0-9]+$ ]] || exit 0
+      (( major < 10 || (major == 10 && minor < 14) ))
+    check: |
+      test -d "$HOME/Screenshots"
+      test "$(defaults read com.apple.screencapture location 2>/dev/null)" = "$HOME/Screenshots"
+    fix: |
+      mkdir -p "$HOME/Screenshots"
+      defaults write com.apple.screencapture location -string "$HOME/Screenshots"

--- a/features/macos-gui/trackpad.rulesy.yaml
+++ b/features/macos-gui/trackpad.rulesy.yaml
@@ -1,0 +1,36 @@
+rules:
+  - name: Swipe between pages is off
+    skip-if: '[[ "$(uname -s)" != "Darwin" ]]'
+    check: |
+      set -e
+      test "$(defaults read NSGlobalDomain AppleEnableSwipeNavigateWithScrolls 2>/dev/null)" = 0
+      test "$(defaults -currentHost read NSGlobalDomain com.apple.trackpad.twoFingerHorizSwipeGesture 2>/dev/null)" = 0
+      test "$(defaults -currentHost read NSGlobalDomain com.apple.trackpad.threeFingerHorizSwipeGesture 2>/dev/null)" = 0
+      test "$(defaults read com.apple.AppleMultitouchTrackpad TrackpadTwoFingerHorizSwipeGesture 2>/dev/null)" = 0
+      test "$(defaults read com.apple.AppleMultitouchTrackpad TrackpadThreeFingerHorizSwipeGesture 2>/dev/null)" = 0
+      test "$(defaults read com.apple.driver.AppleBluetoothMultitouch.trackpad TrackpadTwoFingerHorizSwipeGesture 2>/dev/null)" = 0
+      test "$(defaults read com.apple.driver.AppleBluetoothMultitouch.trackpad TrackpadThreeFingerHorizSwipeGesture 2>/dev/null)" = 0
+    fix: |
+      set -e
+      defaults write NSGlobalDomain AppleEnableSwipeNavigateWithScrolls -bool false
+      defaults -currentHost write NSGlobalDomain com.apple.trackpad.twoFingerHorizSwipeGesture -int 0
+      defaults -currentHost write NSGlobalDomain com.apple.trackpad.threeFingerHorizSwipeGesture -int 0
+      defaults write com.apple.AppleMultitouchTrackpad TrackpadTwoFingerHorizSwipeGesture -int 0
+      defaults write com.apple.AppleMultitouchTrackpad TrackpadThreeFingerHorizSwipeGesture -int 0
+      defaults write com.apple.driver.AppleBluetoothMultitouch.trackpad TrackpadTwoFingerHorizSwipeGesture -int 0
+      defaults write com.apple.driver.AppleBluetoothMultitouch.trackpad TrackpadThreeFingerHorizSwipeGesture -int 0
+      killall cfprefsd >/dev/null 2>&1 || true
+
+  - name: Two-finger Notification Center swipe is off
+    skip-if: '[[ "$(uname -s)" != "Darwin" ]]'
+    check: |
+      set -e
+      test "$(defaults -currentHost read NSGlobalDomain com.apple.trackpad.twoFingerFromRightEdgeSwipeGesture 2>/dev/null)" = 0
+      test "$(defaults read com.apple.AppleMultitouchTrackpad TrackpadTwoFingerFromRightEdgeSwipeGesture 2>/dev/null)" = 0
+      test "$(defaults read com.apple.driver.AppleBluetoothMultitouch.trackpad TrackpadTwoFingerFromRightEdgeSwipeGesture 2>/dev/null)" = 0
+    fix: |
+      set -e
+      defaults -currentHost write NSGlobalDomain com.apple.trackpad.twoFingerFromRightEdgeSwipeGesture -int 0
+      defaults write com.apple.AppleMultitouchTrackpad TrackpadTwoFingerFromRightEdgeSwipeGesture -int 0
+      defaults write com.apple.driver.AppleBluetoothMultitouch.trackpad TrackpadTwoFingerFromRightEdgeSwipeGesture -int 0
+      killall cfprefsd >/dev/null 2>&1 || true

--- a/home/managed_by_dofiles.md
+++ b/home/managed_by_dofiles.md
@@ -30,9 +30,42 @@ git -C "$HOME/.dof/workspace" pull --ff-only
 "$HOME/.dof/workspace/verify.sh"
 ```
 
-The default dof feature installs GNU Stow when needed, preserves backups under
-`$HOME/.dotfiles/backups`, copies the initial entrypoint files, and refreshes
-managed links. Reapplying is supported.
+The default dof feature installs GNU Stow and `$HOME/bin/rulesy` when needed,
+preserves backups under `$HOME/.dotfiles/backups`, copies the initial
+entrypoint files, and refreshes managed links. Reapplying is supported.
+
+On macOS, the `macos-gui` feature uses Rulesy to install Homebrew, append its
+desired formula, casks, and App Store entries to `$HOME/.Brewfile`, and
+reconcile them through `brew bundle --global`.
+
+On macOS 10.14 and newer, it also ensures `$HOME/Screenshots` exists and is
+configured as the screenshot save location. The upper Hot Corners disable the
+screen saver; Command plus either lower corner locks the screen. The
+accessibility rules enable Control-scroll screen zoom. These rules skip on
+other systems.
+
+The Lock Screen rules turn the display off after 10 minutes of inactivity on
+battery and after 60 minutes on a power adapter.
+
+The Trackpad rules disable swiping between pages and the two-finger swipe from
+the right edge that opens Notification Center.
+
+The appearance rules keep macOS in Dark mode. On macOS 26 and newer, they use
+the Clear icon and widget style; the Clear light/dark variant follows the
+system appearance.
+
+The menu bar rules keep the clock digital and always show the date while
+hiding the weekday, AM/PM label, seconds, separator flashing, and time
+announcements.
+On macOS 26 and newer, Wi-Fi, battery, and weather remain visible; Focus,
+Screen Mirroring, Display, Sound, and Timer appear only while active; and
+Spotlight, Bluetooth, AirDrop, Fast User Switching, Text Input, Time Machine,
+Keyboard Brightness, and VPN remain hidden.
+
+On Apple silicon Macs, the `hostname` feature derives a name from the machine
+family, chip tier, and model year, such as `mbp-m4p-2024`. If the computer,
+Bonjour, or network hostname differs, `dof apply` requests administrator
+authentication before reconciling all three.
 
 ## Change A Managed File
 
@@ -57,7 +90,7 @@ git push
 
 This removes Stow-owned links and the Codex config link only when it points
 into the active workspace. It intentionally leaves copied initial files,
-backups, GNU Stow, the dof binary, and dof state in place.
+backups, GNU Stow, Rulesy, the dof binary, and dof state in place.
 
 If an apply reports a conflict, do not delete the target blindly. Determine
 whether it is an unmanaged file, a link from an older checkout, or a managed

--- a/tests/integration.sh
+++ b/tests/integration.sh
@@ -226,6 +226,28 @@ SYSTEM_PROFILER
   fi
 }
 
+run_rulesy_shell_safety_test() {
+  local file
+  local expected
+  local actual
+
+  while read -r file expected; do
+    actual="$(grep -c '^      set -e$' "${SNAPSHOT}/${file}" || true)"
+    [[ "${actual}" -eq "${expected}" ]] ||
+      fail "${file} has ${actual} strict shell blocks; expected ${expected}"
+  done <<'STRICT_BLOCKS'
+features/macos-gui/accessibility.rulesy.yaml 1
+features/macos-gui/appearance.rulesy.yaml 1
+features/macos-gui/screenshots.rulesy.yaml 1
+features/macos-gui/hot-corners.rulesy.yaml 1
+features/hostname/rulesy.yaml 2
+STRICT_BLOCKS
+
+  grep -Fqx '      killall Dock >/dev/null 2>&1 || true' \
+    "${SNAPSHOT}/features/macos-gui/hot-corners.rulesy.yaml" ||
+    fail "Hot Corners does not tolerate Dock already being stopped"
+}
+
 run_normal_home_test() {
   local home="${TEST_ROOT}/normal-home"
   seed_rulesy "${home}"
@@ -317,6 +339,7 @@ run_ambiguous_legacy_test() {
 run_bootstrap_test
 run_rulesy_install_test
 run_hostname_derivation_test
+run_rulesy_shell_safety_test
 run_normal_home_test
 run_symlinked_codex_test
 run_legacy_handoff_test

--- a/tests/integration.sh
+++ b/tests/integration.sh
@@ -40,6 +40,24 @@ assert_link_contains() {
     fail "expected ${path} to point into ${expected}"
 }
 
+seed_rulesy() {
+  local home="$1"
+
+  mkdir -p "${home}/bin"
+  cat >"${home}/bin/rulesy" <<'RULESY'
+#!/bin/sh
+printf '%s\n' "$*" >>"${HOME}/rulesy-calls"
+RULESY
+  chmod 0755 "${home}/bin/rulesy"
+}
+
+seed_dof() {
+  local home="$1"
+
+  mkdir -p "${home}/.dof/bin"
+  cp "${DOF_BIN}" "${home}/.dof/bin/dof"
+}
+
 run_bootstrap_test() {
   local home="${TEST_ROOT}/bootstrap-home"
   local fake_bin="${TEST_ROOT}/fake-bin"
@@ -102,15 +120,132 @@ DOF
   fi
 }
 
+run_rulesy_install_test() {
+  local home="${TEST_ROOT}/rulesy-home"
+  local fake_bin="${TEST_ROOT}/rulesy-fake-bin"
+
+  mkdir -p "${home}" "${fake_bin}"
+  cat >"${fake_bin}/curl" <<'CURL'
+#!/bin/sh
+case "$*" in
+  "-fsSL https://raw.githubusercontent.com/notwillk/rulesy/main/scripts/install.sh") ;;
+  *) printf 'unexpected curl arguments: %s\n' "$*" >&2; exit 1 ;;
+esac
+cat <<'INSTALLER'
+#!/usr/bin/env bash
+set -euo pipefail
+[[ "${DEST:-}" == "${HOME}/bin" ]]
+mkdir -p "${DEST}"
+cat >"${DEST}/rulesy" <<'RULESY'
+#!/bin/sh
+exit 0
+RULESY
+chmod 0755 "${DEST}/rulesy"
+printf 'installed\n' >>"${HOME}/rulesy-installs"
+INSTALLER
+CURL
+  chmod 0755 "${fake_bin}/curl"
+
+  HOME="${home}" PATH="${fake_bin}:${PATH}" "${SNAPSHOT}/features/default/apply"
+  [[ -x "${home}/bin/rulesy" ]] || fail "apply did not install Rulesy to HOME/bin"
+  [[ "$(wc -l <"${home}/rulesy-installs")" -eq 1 ]] ||
+    fail "apply did not run the Rulesy installer exactly once"
+  [[ -f "${home}/.dof/bin/rulesy" && ! -L "${home}/.dof/bin/rulesy" &&
+    -x "${home}/.dof/bin/rulesy" ]] ||
+    fail "apply did not install a regular Rulesy dof entrypoint"
+
+  cat >"${fake_bin}/curl" <<'CURL'
+#!/bin/sh
+printf 'curl must not run when Rulesy is already executable\n' >&2
+exit 99
+CURL
+  HOME="${home}" PATH="${fake_bin}:${PATH}" "${SNAPSHOT}/features/default/apply"
+  [[ "$(wc -l <"${home}/rulesy-installs")" -eq 1 ]] ||
+    fail "reapply unexpectedly reinstalled Rulesy"
+
+  local failure_home="${TEST_ROOT}/rulesy-failure-home"
+  local failure_bin="${TEST_ROOT}/rulesy-failure-bin"
+  mkdir -p "${failure_home}" "${failure_bin}"
+  cat >"${failure_bin}/curl" <<'CURL'
+#!/bin/sh
+exit 19
+CURL
+  chmod 0755 "${failure_bin}/curl"
+
+  if HOME="${failure_home}" PATH="${failure_bin}:${PATH}" \
+    "${SNAPSHOT}/features/default/apply"; then
+    fail "apply ignored a Rulesy installer failure"
+  fi
+  [[ ! -e "${failure_home}/bin/rulesy" && ! -e "${failure_home}/.bashrc" ]] ||
+    fail "failed Rulesy installation continued into dotfile changes"
+}
+
+run_hostname_derivation_test() {
+  local fake_bin="${TEST_ROOT}/hostname-fake-bin"
+  mkdir -p "${fake_bin}"
+
+  cat >"${fake_bin}/uname" <<'UNAME'
+#!/bin/sh
+printf '%s\n' "${FAKE_OS:-Darwin}"
+UNAME
+  cat >"${fake_bin}/ioreg" <<'IOREG'
+#!/bin/sh
+printf '    "product-name" = <"%s">\n' "${FAKE_MARKETING_NAME}"
+IOREG
+  cat >"${fake_bin}/system_profiler" <<'SYSTEM_PROFILER'
+#!/bin/sh
+printf '      Chip: %s\n' "${FAKE_CHIP_NAME}"
+SYSTEM_PROFILER
+  chmod 0755 "${fake_bin}/uname" "${fake_bin}/ioreg" "${fake_bin}/system_profiler"
+
+  local actual
+  actual="$(
+    FAKE_MARKETING_NAME='MacBook Pro (14-inch, Nov 2024)' \
+      FAKE_CHIP_NAME='Apple M4 Pro' \
+      PATH="${fake_bin}:${PATH}" \
+      "${SNAPSHOT}/features/hostname/desired-hostname"
+  )"
+  [[ "${actual}" == "mbp-m4p-2024" ]] ||
+    fail "hostname derivation returned ${actual}, expected mbp-m4p-2024"
+
+  actual="$(
+    FAKE_MARKETING_NAME='Mac Studio (2023)' \
+      FAKE_CHIP_NAME='Apple M2 Ultra' \
+      PATH="${fake_bin}:${PATH}" \
+      "${SNAPSHOT}/features/hostname/desired-hostname"
+  )"
+  [[ "${actual}" == "ms-m2u-2023" ]] ||
+    fail "hostname derivation returned ${actual}, expected ms-m2u-2023"
+
+  if FAKE_OS=Linux \
+    FAKE_MARKETING_NAME='MacBook Pro (14-inch, Nov 2024)' \
+    FAKE_CHIP_NAME='Apple M4 Pro' \
+    PATH="${fake_bin}:${PATH}" \
+    "${SNAPSHOT}/features/hostname/desired-hostname"; then
+    fail "hostname derivation accepted a non-macOS host"
+  fi
+}
+
 run_normal_home_test() {
   local home="${TEST_ROOT}/normal-home"
+  seed_rulesy "${home}"
+  seed_dof "${home}"
   mkdir -p "${home}/keep"
   printf 'unmanaged\n' >"${home}/keep/file"
 
   HOME="${home}" "${DOF_BIN}" clone "${SNAPSHOT_URL}"
-  [[ "$(HOME="${home}" "${DOF_BIN}" features --json)" == '["default"]' ]] ||
-    fail "dof did not discover exactly the default feature"
+  [[ "$(HOME="${home}" "${DOF_BIN}" features --json)" == '["default","hostname","macos-gui"]' ]] ||
+    fail "dof did not discover exactly the intended features"
   HOME="${home}" "${DOF_BIN}" apply
+  [[ -f "${home}/.dof/bin/rulesy" && ! -L "${home}/.dof/bin/rulesy" &&
+    -x "${home}/.dof/bin/rulesy" ]] ||
+    fail "default did not install a regular Rulesy dof entrypoint"
+  [[ "$(sed -n '1p' "${home}/rulesy-calls")" == \
+    "--config=${home}/.dof/workspace/features/hostname/rulesy.yaml check --fix" ]] ||
+    fail "hostname did not invoke Rulesy through dof with the expected arguments"
+  [[ "$(sed -n '2p' "${home}/rulesy-calls")" == \
+    "--config=${home}/.dof/workspace/features/macos-gui/rulesy.yaml check --fix --non-interactive" ]] ||
+    fail "macos-gui did not invoke Rulesy through dof with the expected arguments"
 
   [[ -f "${home}/.bashrc" && ! -L "${home}/.bashrc" ]] ||
     fail "initial .bashrc is not a regular file"
@@ -124,20 +259,21 @@ run_normal_home_test() {
     fail "reapply did not back up the copied initial file"
 
   HOME="${home}" "${home}/.dof/workspace/verify.sh"
-  mkdir -p "${home}/.dof/bin"
-  cp "${DOF_BIN}" "${home}/.dof/bin/dof"
   HOME="${home}" bash --noprofile --rcfile "${home}/.bashrc" -i -c '[[ "$(command -v dof)" == "$HOME/.dof/bin/dof" ]]'
 
   HOME="${home}" "${home}/.dof/workspace/uninstall.sh"
   [[ ! -e "${home}/managed_by_dofiles.md" && ! -L "${home}/managed_by_dofiles.md" ]] ||
     fail "uninstall left the managed marker link"
-  [[ -f "${home}/.bashrc" && -x "${home}/.dof/bin/dof" ]] ||
-    fail "uninstall removed copied files or dof"
+  [[ -f "${home}/.bashrc" && -x "${home}/.dof/bin/dof" &&
+    -x "${home}/.dof/bin/rulesy" && -x "${home}/bin/rulesy" ]] ||
+    fail "uninstall removed copied files, dof, or Rulesy"
 }
 
 run_symlinked_codex_test() {
   local home="${TEST_ROOT}/codex-home"
   local external="${TEST_ROOT}/codex-external"
+  seed_rulesy "${home}"
+  seed_dof "${home}"
   mkdir -p "${home}" "${external}"
   ln -s "${external}" "${home}/.codex"
 
@@ -148,6 +284,8 @@ run_symlinked_codex_test() {
 
 run_legacy_handoff_test() {
   local home="${TEST_ROOT}/legacy-home"
+  seed_rulesy "${home}"
+  seed_dof "${home}"
   mkdir -p "${home}"
 
   HOME="${home}" "${SNAPSHOT}/features/default/apply"
@@ -162,6 +300,8 @@ run_legacy_handoff_test() {
 run_ambiguous_legacy_test() {
   local home="${TEST_ROOT}/ambiguous-home"
   local unrelated="${TEST_ROOT}/unrelated-marker"
+  seed_rulesy "${home}"
+  seed_dof "${home}"
   mkdir -p "${home}"
   printf 'unrelated\n' >"${unrelated}"
   ln -s "${unrelated}" "${home}/managed_by_dofiles.md"
@@ -175,6 +315,8 @@ run_ambiguous_legacy_test() {
 }
 
 run_bootstrap_test
+run_rulesy_install_test
+run_hostname_derivation_test
 run_normal_home_test
 run_symlinked_codex_test
 run_legacy_handoff_test

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -144,6 +144,14 @@ run_case() {
         fi
       }
 
+      seed_rulesy() {
+        local home="$1"
+
+        mkdir -p "${home}/bin"
+        : >"${home}/bin/rulesy"
+        chmod 0755 "${home}/bin/rulesy"
+      }
+
       assert_installed_ownership() {
         assert_directory_not_symlink "${HOME}/.ssh"
         assert_directory_not_symlink "${HOME}/.ssh/config.d"
@@ -219,8 +227,13 @@ run_case() {
       }
 
       run_normal_lifecycle() {
+        seed_rulesy "${HOME}"
         expect_pass "syntax: install.sh" bash -n ./install.sh
         expect_pass "syntax: features/default/apply" bash -n ./features/default/apply
+        expect_pass "syntax: features/hostname/apply" bash -n ./features/hostname/apply
+        expect_pass "syntax: features/hostname/desired-hostname" \
+          bash -n ./features/hostname/desired-hostname
+        expect_pass "syntax: features/macos-gui/apply" bash -n ./features/macos-gui/apply
         expect_pass "syntax: uninstall.sh" bash -n ./uninstall.sh
         expect_pass "syntax: verify.sh" bash -n ./verify.sh
         run_dotfile_tests
@@ -234,15 +247,18 @@ run_case() {
         expect_fail "uninstall with missing HOME" env HOME=/tmp/does-not-exist ./uninstall.sh
 
         mkdir -p /tmp/conflict-home
+        seed_rulesy /tmp/conflict-home
         printf "not managed by stow\n" > /tmp/conflict-home/managed_by_dofiles.md
         expect_fail "install with existing target conflict" env HOME=/tmp/conflict-home ./features/default/apply
 
         mkdir -p /tmp/initial-file-directory-conflict/.ssh/config
+        seed_rulesy /tmp/initial-file-directory-conflict
         expect_fail \
           "install with initial file directory conflict" \
           env HOME=/tmp/initial-file-directory-conflict ./features/default/apply
 
         mkdir -p /tmp/codex-backup-home/.codex
+        seed_rulesy /tmp/codex-backup-home
         printf "local codex config\n" > /tmp/codex-backup-home/.codex/config.toml
         expect_pass \
           "install backs up existing Codex config under dotfiles backups" \
@@ -259,6 +275,7 @@ run_case() {
 
         if command -v su >/dev/null 2>&1; then
           mkdir -p /tmp/readonly-home
+          seed_rulesy /tmp/readonly-home
           chmod 0555 /tmp/readonly-home
           expect_fail \
             "install with read-only HOME" \
@@ -282,8 +299,13 @@ run_case() {
       }
 
       run_no_package_manager_case() {
+        seed_rulesy "${HOME}"
         expect_pass "syntax: install.sh" bash -n ./install.sh
         expect_pass "syntax: features/default/apply" bash -n ./features/default/apply
+        expect_pass "syntax: features/hostname/apply" bash -n ./features/hostname/apply
+        expect_pass "syntax: features/hostname/desired-hostname" \
+          bash -n ./features/hostname/desired-hostname
+        expect_pass "syntax: features/macos-gui/apply" bash -n ./features/macos-gui/apply
         expect_pass "syntax: uninstall.sh" bash -n ./uninstall.sh
         expect_pass "syntax: verify.sh" bash -n ./verify.sh
         run_dotfile_tests


### PR DESCRIPTION
## Summary

- install Rulesy through the default dof feature and expose it through `dof run rulesy`
- add a hardware-derived macOS hostname feature
- add a `macos-gui` feature for Homebrew/Brewfile apps, screenshots, hot corners, accessibility, appearance, menu bar, lock screen, and trackpad preferences
- document the new maintenance behavior and expand isolated-home integration coverage

## Why

This keeps machine setup declarative and idempotent within dof while preserving GNU Stow as the existing dotfile linker. Rules are split by concern so future macOS changes stay localized and testable.

## Validation

- `bash -n install.sh features/default/apply features/hostname/apply features/hostname/desired-hostname features/macos-gui/apply uninstall.sh verify.sh tests/run.sh tests/integration.sh`
- `dof lint .` using dof 0.1.7
- real Rulesy fix/post-fix simulations for Brewfile, lock-screen, menu-bar, and trackpad rules
- `DOF_BIN=/tmp/dof-v017-check.R7vrht/bin/dof tests/integration.sh`
- `git diff --check`

Docker is unavailable in this environment, so `tests/run.sh --all` was not run.
