### PR TITLE
Manage GPG through Rulesy

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,8 +10,10 @@ dof declarations live in `features/default/`, `features/hostname/`, and
 
 This is a transitional architecture: `features/default/apply` installs GNU
 Stow and Rulesy when needed, exposes Rulesy through `dof run`, copies
-`initial-files/`, and Stows `home/` into the target `$HOME`. Do not convert
-payload files to native dof ownership unless explicitly asked.
+`initial-files/`, and Stows `home/` into the target `$HOME`. Its Rulesy
+configuration conditionally installs GPG through the first available supported
+package manager before changing dotfile targets. Do not convert payload files
+to native dof ownership unless explicitly asked.
 
 The canonical checkout is `$HOME/.dof/workspace`. Files under `home/` map to
 the same relative path beneath `$HOME`; files under `initial-files/` are
@@ -22,7 +24,10 @@ copied as regular files.
 - `./install.sh` bootstraps `$HOME/.dof/bin/dof`, clones this repository, and
   runs `dof apply`.
 - `features/default/apply` is the idempotent feature hook and underlying
-  installer.
+  installer. After installing Rulesy, it runs
+  `features/default/rulesy.yaml` with fixes enabled before copying or linking
+  dotfiles. The GPG rules are post-bootstrap maintenance and cannot satisfy
+  dof's own installer prerequisites.
 - `features/hostname/apply` derives the hardware-based macOS hostname and runs
   its local Rulesy configuration through `dof run rulesy`.
 - `features/macos-gui/apply` runs its local Rulesy configuration through
@@ -71,7 +76,7 @@ Run:
 ```sh
 bash -n install.sh features/default/apply features/hostname/apply \
   features/hostname/desired-hostname features/macos-gui/apply uninstall.sh \
-  verify.sh tests/run.sh
+  verify.sh tests/run.sh tests/support/fake-dof.sh
 dof lint .
 tests/run.sh --all
 ```
@@ -80,6 +85,6 @@ The Docker tests use isolated temporary homes and local repository snapshots;
 they must never install into the real `$HOME`. They cover package-manager
 selection, bootstrap delegation, dof apply, Stow ownership, legacy handoff,
 backups, conflicts, Rulesy delegation, hostname derivation, macOS gating,
-verification, and uninstall behavior.
+GPG package-manager selection, verification, and uninstall behavior.
 
 If Docker is unavailable, state that clearly in the final message.

--- a/README.md
+++ b/README.md
@@ -6,6 +6,13 @@ The transitional `default` feature uses GNU Stow to link the existing `home/`
 payload and preserves the copied `initial-files/` behavior. Human-facing update
 and recovery notes are installed as `managed_by_dofiles.md`.
 
+The `default` feature also uses Rulesy to install GPG through the first
+supported package manager already present on the machine. It follows the same
+manager precedence as the Stow installer and skips cleanly when GPG is already
+installed or no supported manager is available. This is post-bootstrap
+maintenance: dof's own installer must still be able to complete before the
+default feature can run.
+
 The `macos-gui` feature uses Rulesy to install Homebrew, append its desired
 formula, casks, and App Store entries to `$HOME/.Brewfile`, and reconcile them
 through `brew bundle --global`. It keeps macOS screenshot storage pointed at

--- a/features/default/apply
+++ b/features/default/apply
@@ -66,6 +66,7 @@ if [[ -n "${ACCOUNT_HOME}" && "${HOME}" != "${ACCOUNT_HOME}" ]]; then
 fi
 
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+FEATURE_ROOT="${REPO_ROOT}/features/default"
 DOTFILES_SOURCE_PATH="${REPO_ROOT}/home"
 INITIAL_FILES_SOURCE_PATH="${REPO_ROOT}/initial-files"
 DOTFILES_STATE_PATH="${HOME}/.dotfiles"
@@ -308,6 +309,11 @@ fi
 
 install_rulesy
 install_rulesy_for_dof
+
+"${HOME}/.dof/bin/dof" run rulesy \
+  "--config=${FEATURE_ROOT}/rulesy.yaml" \
+  check \
+  --fix
 
 resolve_link_target() {
   local link_path="$1"

--- a/features/default/gpg.rulesy.yaml
+++ b/features/default/gpg.rulesy.yaml
@@ -1,0 +1,216 @@
+rules:
+  - name: GPG is installed with Homebrew
+    skip-if: |
+      command -v gpg >/dev/null 2>&1 ||
+        ! command -v brew >/dev/null 2>&1
+    check: command -v gpg >/dev/null 2>&1
+    fix: brew install gnupg
+
+  - name: GPG is installed with apt-get
+    skip-if: |
+      command -v gpg >/dev/null 2>&1 ||
+        command -v brew >/dev/null 2>&1 ||
+        ! command -v apt-get >/dev/null 2>&1
+    check: command -v gpg >/dev/null 2>&1
+    interactive-fix: |
+      run_privileged() {
+        if [[ "${EUID:-$(id -u)}" -eq 0 ]]; then
+          "$@"
+        elif command -v sudo >/dev/null 2>&1; then
+          sudo "$@"
+        else
+          printf 'GPG installation requires root or sudo.\n' >&2
+          return 1
+        fi
+      }
+      run_privileged apt-get update
+      run_privileged apt-get install -y gnupg
+
+  - name: GPG is installed with apt
+    skip-if: |
+      command -v gpg >/dev/null 2>&1 ||
+        command -v brew >/dev/null 2>&1 ||
+        command -v apt-get >/dev/null 2>&1 ||
+        ! command -v apt >/dev/null 2>&1
+    check: command -v gpg >/dev/null 2>&1
+    interactive-fix: |
+      run_privileged() {
+        if [[ "${EUID:-$(id -u)}" -eq 0 ]]; then
+          "$@"
+        elif command -v sudo >/dev/null 2>&1; then
+          sudo "$@"
+        else
+          printf 'GPG installation requires root or sudo.\n' >&2
+          return 1
+        fi
+      }
+      run_privileged apt update
+      run_privileged apt install -y gnupg
+
+  - name: GPG is installed with dnf
+    skip-if: |
+      command -v gpg >/dev/null 2>&1 ||
+        command -v brew >/dev/null 2>&1 ||
+        command -v apt-get >/dev/null 2>&1 ||
+        command -v apt >/dev/null 2>&1 ||
+        ! command -v dnf >/dev/null 2>&1
+    check: command -v gpg >/dev/null 2>&1
+    interactive-fix: |
+      run_privileged() {
+        if [[ "${EUID:-$(id -u)}" -eq 0 ]]; then
+          "$@"
+        elif command -v sudo >/dev/null 2>&1; then
+          sudo "$@"
+        else
+          printf 'GPG installation requires root or sudo.\n' >&2
+          return 1
+        fi
+      }
+      run_privileged dnf install -y gnupg2
+
+  - name: GPG is installed with yum
+    skip-if: |
+      command -v gpg >/dev/null 2>&1 ||
+        command -v brew >/dev/null 2>&1 ||
+        command -v apt-get >/dev/null 2>&1 ||
+        command -v apt >/dev/null 2>&1 ||
+        command -v dnf >/dev/null 2>&1 ||
+        ! command -v yum >/dev/null 2>&1
+    check: command -v gpg >/dev/null 2>&1
+    interactive-fix: |
+      run_privileged() {
+        if [[ "${EUID:-$(id -u)}" -eq 0 ]]; then
+          "$@"
+        elif command -v sudo >/dev/null 2>&1; then
+          sudo "$@"
+        else
+          printf 'GPG installation requires root or sudo.\n' >&2
+          return 1
+        fi
+      }
+      run_privileged yum install -y gnupg2
+
+  - name: GPG is installed with pacman
+    skip-if: |
+      command -v gpg >/dev/null 2>&1 ||
+        command -v brew >/dev/null 2>&1 ||
+        command -v apt-get >/dev/null 2>&1 ||
+        command -v apt >/dev/null 2>&1 ||
+        command -v dnf >/dev/null 2>&1 ||
+        command -v yum >/dev/null 2>&1 ||
+        ! command -v pacman >/dev/null 2>&1
+    check: command -v gpg >/dev/null 2>&1
+    interactive-fix: |
+      run_privileged() {
+        if [[ "${EUID:-$(id -u)}" -eq 0 ]]; then
+          "$@"
+        elif command -v sudo >/dev/null 2>&1; then
+          sudo "$@"
+        else
+          printf 'GPG installation requires root or sudo.\n' >&2
+          return 1
+        fi
+      }
+      run_privileged pacman -Sy --noconfirm gnupg
+
+  - name: GPG is installed with zypper
+    skip-if: |
+      command -v gpg >/dev/null 2>&1 ||
+        command -v brew >/dev/null 2>&1 ||
+        command -v apt-get >/dev/null 2>&1 ||
+        command -v apt >/dev/null 2>&1 ||
+        command -v dnf >/dev/null 2>&1 ||
+        command -v yum >/dev/null 2>&1 ||
+        command -v pacman >/dev/null 2>&1 ||
+        ! command -v zypper >/dev/null 2>&1
+    check: command -v gpg >/dev/null 2>&1
+    interactive-fix: |
+      run_privileged() {
+        if [[ "${EUID:-$(id -u)}" -eq 0 ]]; then
+          "$@"
+        elif command -v sudo >/dev/null 2>&1; then
+          sudo "$@"
+        else
+          printf 'GPG installation requires root or sudo.\n' >&2
+          return 1
+        fi
+      }
+      run_privileged zypper --non-interactive install gpg2
+
+  - name: GPG is installed with apk
+    skip-if: |
+      command -v gpg >/dev/null 2>&1 ||
+        command -v brew >/dev/null 2>&1 ||
+        command -v apt-get >/dev/null 2>&1 ||
+        command -v apt >/dev/null 2>&1 ||
+        command -v dnf >/dev/null 2>&1 ||
+        command -v yum >/dev/null 2>&1 ||
+        command -v pacman >/dev/null 2>&1 ||
+        command -v zypper >/dev/null 2>&1 ||
+        ! command -v apk >/dev/null 2>&1
+    check: command -v gpg >/dev/null 2>&1
+    interactive-fix: |
+      run_privileged() {
+        if [[ "${EUID:-$(id -u)}" -eq 0 ]]; then
+          "$@"
+        elif command -v sudo >/dev/null 2>&1; then
+          sudo "$@"
+        else
+          printf 'GPG installation requires root or sudo.\n' >&2
+          return 1
+        fi
+      }
+      run_privileged apk add gnupg
+
+  - name: GPG is installed with xbps-install
+    skip-if: |
+      command -v gpg >/dev/null 2>&1 ||
+        command -v brew >/dev/null 2>&1 ||
+        command -v apt-get >/dev/null 2>&1 ||
+        command -v apt >/dev/null 2>&1 ||
+        command -v dnf >/dev/null 2>&1 ||
+        command -v yum >/dev/null 2>&1 ||
+        command -v pacman >/dev/null 2>&1 ||
+        command -v zypper >/dev/null 2>&1 ||
+        command -v apk >/dev/null 2>&1 ||
+        ! command -v xbps-install >/dev/null 2>&1
+    check: command -v gpg >/dev/null 2>&1
+    interactive-fix: |
+      run_privileged() {
+        if [[ "${EUID:-$(id -u)}" -eq 0 ]]; then
+          "$@"
+        elif command -v sudo >/dev/null 2>&1; then
+          sudo "$@"
+        else
+          printf 'GPG installation requires root or sudo.\n' >&2
+          return 1
+        fi
+      }
+      run_privileged xbps-install -Sy gnupg2
+
+  - name: GPG is installed with pkg
+    skip-if: |
+      command -v gpg >/dev/null 2>&1 ||
+        command -v brew >/dev/null 2>&1 ||
+        command -v apt-get >/dev/null 2>&1 ||
+        command -v apt >/dev/null 2>&1 ||
+        command -v dnf >/dev/null 2>&1 ||
+        command -v yum >/dev/null 2>&1 ||
+        command -v pacman >/dev/null 2>&1 ||
+        command -v zypper >/dev/null 2>&1 ||
+        command -v apk >/dev/null 2>&1 ||
+        command -v xbps-install >/dev/null 2>&1 ||
+        ! command -v pkg >/dev/null 2>&1
+    check: command -v gpg >/dev/null 2>&1
+    interactive-fix: |
+      run_privileged() {
+        if [[ "${EUID:-$(id -u)}" -eq 0 ]]; then
+          "$@"
+        elif command -v sudo >/dev/null 2>&1; then
+          sudo "$@"
+        else
+          printf 'GPG installation requires root or sudo.\n' >&2
+          return 1
+        fi
+      }
+      run_privileged pkg install -y gnupg

--- a/features/default/rulesy.yaml
+++ b/features/default/rulesy.yaml
@@ -1,0 +1,2 @@
+rules:
+  - remote: gpg.rulesy.yaml

--- a/tests/integration.sh
+++ b/tests/integration.sh
@@ -47,6 +47,13 @@ seed_rulesy() {
   cat >"${home}/bin/rulesy" <<'RULESY'
 #!/bin/sh
 printf '%s\n' "$*" >>"${HOME}/rulesy-calls"
+case "$*" in
+  *"/features/default/rulesy.yaml "*)
+    if [ "${FAIL_DEFAULT_RULESY:-0}" = 1 ]; then
+      exit 23
+    fi
+    ;;
+esac
 RULESY
   chmod 0755 "${home}/bin/rulesy"
 }
@@ -125,6 +132,7 @@ run_rulesy_install_test() {
   local fake_bin="${TEST_ROOT}/rulesy-fake-bin"
 
   mkdir -p "${home}" "${fake_bin}"
+  seed_dof "${home}"
   cat >"${fake_bin}/curl" <<'CURL'
 #!/bin/sh
 case "$*" in
@@ -178,6 +186,89 @@ CURL
   fi
   [[ ! -e "${failure_home}/bin/rulesy" && ! -e "${failure_home}/.bashrc" ]] ||
     fail "failed Rulesy installation continued into dotfile changes"
+}
+
+run_default_rulesy_contract_test() {
+  local config="${SNAPSHOT}/features/default/gpg.rulesy.yaml"
+  local main_config="${SNAPSHOT}/features/default/rulesy.yaml"
+  local previous_line=0
+  local line
+  local rule_name
+  local rule_block
+  local manager
+  local higher_manager
+  local package
+  local expected_command
+  local -a prior_managers=()
+
+  [[ "$(cat "${main_config}")" == $'rules:\n  - remote: gpg.rulesy.yaml' ]] ||
+    fail "default rulesy.yaml must contain only the GPG remote"
+  [[ "$(grep -c '^  - name: GPG is installed with ' "${config}")" -eq 10 ]] ||
+    fail "GPG configuration does not contain exactly ten installer rules"
+  [[ "$(grep -c '^    check: command -v gpg >/dev/null 2>&1$' "${config}")" -eq 10 ]] ||
+    fail "every GPG installer rule must check the exact gpg executable"
+  [[ "$(grep -c '^      command -v gpg >/dev/null 2>&1 ||$' "${config}")" -eq 10 ]] ||
+    fail "every GPG installer rule must skip when gpg already exists"
+  [[ "$(grep -c '^    fix: brew install gnupg$' "${config}")" -eq 1 ]] ||
+    fail "Homebrew GPG repair must be non-interactive"
+  [[ "$(grep -c '^    interactive-fix: |$' "${config}")" -eq 9 ]] ||
+    fail "system GPG repairs must remain interactive"
+  [[ "$(grep -cF '        if [[ "${EUID:-$(id -u)}" -eq 0 ]]; then' "${config}")" -eq 9 ]] ||
+    fail "system GPG repairs must run directly as root"
+  [[ "$(grep -c '^        elif command -v sudo >/dev/null 2>&1; then$' "${config}")" -eq 9 ]] ||
+    fail "system GPG repairs must fall back to sudo"
+
+  while read -r rule_name manager package expected_command; do
+    line="$(grep -nFx "  - name: GPG is installed with ${rule_name}" "${config}" | cut -d: -f1)"
+    [[ -n "${line}" && "${line}" -gt "${previous_line}" ]] ||
+      fail "GPG manager precedence is incorrect at ${manager}"
+    previous_line="${line}"
+
+    rule_block="$(
+      awk -v heading="  - name: GPG is installed with ${rule_name}" '
+        $0 == heading { selected = 1; next }
+        selected && /^  - name:/ { exit }
+        selected { print }
+      ' "${config}"
+    )"
+    grep -Fq "! command -v ${manager} >/dev/null 2>&1" <<<"${rule_block}" ||
+      fail "GPG rule for ${manager} does not skip when its manager is absent"
+    for higher_manager in "${prior_managers[@]}"; do
+      grep -Fq "command -v ${higher_manager} >/dev/null 2>&1 ||" <<<"${rule_block}" ||
+        fail "GPG rule for ${manager} does not defer to ${higher_manager}"
+    done
+    prior_managers+=("${manager}")
+
+    if [[ "${manager}" != brew ]]; then
+      grep -Fqx "      ${expected_command}" <<<"${rule_block}" ||
+        fail "GPG rule for ${manager} does not install package ${package} correctly"
+    fi
+  done <<'GPG_MANAGERS'
+Homebrew brew gnupg brew install gnupg
+apt-get apt-get gnupg run_privileged apt-get install -y gnupg
+apt apt gnupg run_privileged apt install -y gnupg
+dnf dnf gnupg2 run_privileged dnf install -y gnupg2
+yum yum gnupg2 run_privileged yum install -y gnupg2
+pacman pacman gnupg run_privileged pacman -Sy --noconfirm gnupg
+zypper zypper gpg2 run_privileged zypper --non-interactive install gpg2
+apk apk gnupg run_privileged apk add gnupg
+xbps-install xbps-install gnupg2 run_privileged xbps-install -Sy gnupg2
+pkg pkg gnupg run_privileged pkg install -y gnupg
+GPG_MANAGERS
+}
+
+run_default_rulesy_failure_test() {
+  local home="${TEST_ROOT}/default-rulesy-failure-home"
+
+  seed_rulesy "${home}"
+  seed_dof "${home}"
+  mkdir -p "${home}"
+
+  if HOME="${home}" FAIL_DEFAULT_RULESY=1 "${SNAPSHOT}/features/default/apply"; then
+    fail "default apply ignored a Rulesy failure"
+  fi
+  [[ ! -e "${home}/.bashrc" && ! -L "${home}/managed_by_dofiles.md" ]] ||
+    fail "default Rulesy failure changed dotfile targets"
 }
 
 run_hostname_derivation_test() {
@@ -263,9 +354,12 @@ run_normal_home_test() {
     -x "${home}/.dof/bin/rulesy" ]] ||
     fail "default did not install a regular Rulesy dof entrypoint"
   [[ "$(sed -n '1p' "${home}/rulesy-calls")" == \
+    "--config=${home}/.dof/workspace/features/default/rulesy.yaml check --fix" ]] ||
+    fail "default did not invoke Rulesy through dof with fixes enabled"
+  [[ "$(sed -n '2p' "${home}/rulesy-calls")" == \
     "--config=${home}/.dof/workspace/features/hostname/rulesy.yaml check --fix" ]] ||
     fail "hostname did not invoke Rulesy through dof with the expected arguments"
-  [[ "$(sed -n '2p' "${home}/rulesy-calls")" == \
+  [[ "$(sed -n '3p' "${home}/rulesy-calls")" == \
     "--config=${home}/.dof/workspace/features/macos-gui/rulesy.yaml check --fix --non-interactive" ]] ||
     fail "macos-gui did not invoke Rulesy through dof with the expected arguments"
 
@@ -276,6 +370,9 @@ run_normal_home_test() {
     fail "apply changed an unrelated file"
 
   HOME="${home}" "${DOF_BIN}" apply
+  [[ "$(sed -n '4p' "${home}/rulesy-calls")" == \
+    "--config=${home}/.dof/workspace/features/default/rulesy.yaml check --fix" ]] ||
+    fail "reapply did not rerun the default Rulesy configuration first"
   assert_link_contains "${home}/managed_by_dofiles.md" ".dof/workspace/home"
   compgen -G "${home}/.dotfiles/backups/.bashrc.backup.*" >/dev/null ||
     fail "reapply did not back up the copied initial file"
@@ -338,6 +435,8 @@ run_ambiguous_legacy_test() {
 
 run_bootstrap_test
 run_rulesy_install_test
+run_default_rulesy_contract_test
+run_default_rulesy_failure_test
 run_hostname_derivation_test
 run_rulesy_shell_safety_test
 run_normal_home_test

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -147,9 +147,11 @@ run_case() {
       seed_rulesy() {
         local home="$1"
 
-        mkdir -p "${home}/bin"
+        mkdir -p "${home}/bin" "${home}/.dof/bin"
         : >"${home}/bin/rulesy"
         chmod 0755 "${home}/bin/rulesy"
+        cp ./tests/support/fake-dof.sh "${home}/.dof/bin/dof"
+        chmod 0755 "${home}/.dof/bin/dof"
       }
 
       assert_installed_ownership() {
@@ -234,6 +236,7 @@ run_case() {
         expect_pass "syntax: features/hostname/desired-hostname" \
           bash -n ./features/hostname/desired-hostname
         expect_pass "syntax: features/macos-gui/apply" bash -n ./features/macos-gui/apply
+        expect_pass "syntax: tests/support/fake-dof.sh" bash -n ./tests/support/fake-dof.sh
         expect_pass "syntax: uninstall.sh" bash -n ./uninstall.sh
         expect_pass "syntax: verify.sh" bash -n ./verify.sh
         run_dotfile_tests
@@ -306,6 +309,7 @@ run_case() {
         expect_pass "syntax: features/hostname/desired-hostname" \
           bash -n ./features/hostname/desired-hostname
         expect_pass "syntax: features/macos-gui/apply" bash -n ./features/macos-gui/apply
+        expect_pass "syntax: tests/support/fake-dof.sh" bash -n ./tests/support/fake-dof.sh
         expect_pass "syntax: uninstall.sh" bash -n ./uninstall.sh
         expect_pass "syntax: verify.sh" bash -n ./verify.sh
         run_dotfile_tests

--- a/tests/support/fake-dof.sh
+++ b/tests/support/fake-dof.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ "${1:-}" != run || "${2:-}" != rulesy ]]; then
+  printf 'unsupported test dof invocation: %s\n' "$*" >&2
+  exit 1
+fi
+
+shift 2
+exec "${HOME}/.dof/bin/rulesy" "$@"


### PR DESCRIPTION
## Summary

- add a remote-only default Rulesy configuration for GPG
- install GPG through the first available package manager in the existing Stow precedence order
- run the default Rulesy configuration with fixes enabled before copying or linking dotfiles
- add isolated-home coverage for ordering, idempotence, failure safety, manager precedence, and privilege handling

## Why

dof uses GPG for release-signature validation, but GPG may not remain available after an upstream bootstrap fallback is used on a fresh machine. This change makes GPG a post-bootstrap default-feature dependency without duplicating dof's installer verification logic.

Machines that already have GPG skip every installer rule. Machines without GPG select the first supported package manager; machines without any supported manager skip cleanly.

This does not solve the initial dof bootstrap dependency by itself. The separate dof installer fallback must land independently so the default feature can be reached on a stock machine without GPG.

## Validation

- shell syntax checks for installers, feature hooks, lifecycle scripts, and test helpers
- `git diff --check`
- `dof lint .` with dof v0.1.7
- real Rulesy v0.8.3 configuration validation
- real Rulesy no-manager skip and fake-Homebrew repair scenarios
- full isolated custom-`HOME` integration suite

Docker is unavailable in this environment, so `tests/run.sh --all` could not run its Docker package-manager matrix.
