### PR TITLE
Manage GNU Stow through Rulesy

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,12 +8,13 @@ Dof owns bootstrap, workspace selection, and feature execution. Intentional
 dof declarations live in `features/default/`, `features/hostname/`, and
 `features/macos-gui/`.
 
-This is a transitional architecture: `features/default/apply` installs GNU
-Stow and Rulesy when needed, exposes Rulesy through `dof run`, copies
-`initial-files/`, and Stows `home/` into the target `$HOME`. Its Rulesy
-configuration conditionally installs GPG through the first available supported
-package manager before changing dotfile targets. Do not convert payload files
-to native dof ownership unless explicitly asked.
+This is a transitional architecture: `features/default/apply` installs
+Rulesy when needed, exposes it through `dof run`, copies `initial-files/`,
+and manages the special Codex link. Its Rulesy configuration installs GPG and
+GNU Stow through the first available supported package manager, then checks and
+reconciles `home/` through the shared
+`features/default/scripts/stow-home-files` helper. Do not convert payload
+files to native dof ownership unless explicitly asked.
 
 The canonical checkout is `$HOME/.dof/workspace`. Files under `home/` map to
 the same relative path beneath `$HOME`; files under `initial-files/` are
@@ -24,18 +25,20 @@ copied as regular files.
 - `./install.sh` bootstraps `$HOME/.dof/bin/dof`, clones this repository, and
   runs `dof apply`.
 - `features/default/apply` is the idempotent feature hook and underlying
-  installer. After installing Rulesy, it runs
-  `features/default/rulesy.yaml` with fixes enabled before copying or linking
-  dotfiles. The GPG rules are post-bootstrap maintenance and cannot satisfy
-  dof's own installer prerequisites.
+  installer. After installing Rulesy, it runs the default Rulesy configuration
+  with fixes enabled before copying initial files or linking Codex config.
+  Rulesy installs GPG and Stow, hands off recognized legacy Stow ownership, and
+  reconciles the active home package. The GPG rules are post-bootstrap
+  maintenance and cannot satisfy dof's own installer prerequisites.
 - `features/hostname/apply` derives the hardware-based macOS hostname and runs
   its local Rulesy configuration through `dof run rulesy`.
 - `features/macos-gui/apply` runs its local Rulesy configuration through
   `dof run rulesy`. Its app rules append exact entries to `$HOME/.Brewfile`,
   then reconcile it through Homebrew Bundle.
-- `verify.sh` simulates Stow and checks the special Codex config link.
-- `uninstall.sh` removes `home/` Stow-owned links and the exact managed Codex
-  link.
+- `verify.sh` delegates home-package simulation to the shared helper and checks
+  the special Codex config link.
+- `uninstall.sh` delegates active-workspace unstowing to the shared helper and
+  removes the exact managed Codex link.
 
 Normal maintenance is:
 
@@ -57,9 +60,10 @@ a real directory or a directory symlink. The apply hook backs up an unmanaged
 leaf and creates the exact config symlink. Uninstall removes it only when it
 points into the active workspace.
 
-The apply hook may automatically hand off links from an older checkout. It must
-only unstow a package identified by the installed marker link and must never
-use `stow --adopt`, delete unmanaged files, or use `dof clone --force`.
+The shared home-files helper may automatically hand off links from an older
+checkout. It must only unstow a package identified by the installed marker
+link and must never use `stow --adopt`, delete unmanaged files, accept an
+arbitrary target path, or use `dof clone --force`.
 
 ## Workspace Rules
 
@@ -75,8 +79,9 @@ Run:
 
 ```sh
 bash -n install.sh features/default/apply features/hostname/apply \
-  features/hostname/desired-hostname features/macos-gui/apply uninstall.sh \
-  verify.sh tests/run.sh tests/support/fake-dof.sh
+  features/default/scripts/stow-home-files features/hostname/desired-hostname \
+  features/macos-gui/apply uninstall.sh verify.sh tests/run.sh \
+  tests/support/fake-dof.sh
 dof lint .
 tests/run.sh --all
 ```
@@ -85,6 +90,7 @@ The Docker tests use isolated temporary homes and local repository snapshots;
 they must never install into the real `$HOME`. They cover package-manager
 selection, bootstrap delegation, dof apply, Stow ownership, legacy handoff,
 backups, conflicts, Rulesy delegation, hostname derivation, macOS gating,
-GPG package-manager selection, verification, and uninstall behavior.
+GPG and Stow package-manager selection, shared-helper verification, and
+uninstall behavior.
 
 If Docker is unavailable, state that clearly in the final message.

--- a/README.md
+++ b/README.md
@@ -2,16 +2,17 @@
 
 Personal dotfiles orchestrated by [dof](https://github.com/notwillk/dof).
 
-The transitional `default` feature uses GNU Stow to link the existing `home/`
-payload and preserves the copied `initial-files/` behavior. Human-facing update
-and recovery notes are installed as `managed_by_dofiles.md`.
+The transitional `default` feature uses Rulesy to install GPG and GNU Stow,
+then checks and reconciles the existing `home/` payload through a shared Stow
+lifecycle helper. The feature hook itself retains only Rulesy bootstrap,
+copied `initial-files/`, and the special Codex config link. Human-facing
+update and recovery notes are installed as `managed_by_dofiles.md`.
 
-The `default` feature also uses Rulesy to install GPG through the first
-supported package manager already present on the machine. It follows the same
-manager precedence as the Stow installer and skips cleanly when GPG is already
-installed or no supported manager is available. This is post-bootstrap
-maintenance: dof's own installer must still be able to complete before the
-default feature can run.
+GPG and Stow use the first supported package manager already present on the
+machine, with Homebrew preferred before the supported system managers. A
+missing prerequisite fails before home links, copied initial files, or the
+Codex link are changed. This remains post-bootstrap maintenance: dof's own
+installer must still be able to complete before the default feature can run.
 
 The `macos-gui` feature uses Rulesy to install Homebrew, append its desired
 formula, casks, and App Store entries to `$HOME/.Brewfile`, and reconcile them

--- a/features/default/apply
+++ b/features/default/apply
@@ -18,15 +18,11 @@ trap on_exit EXIT
 prepend() {
   local prefix="$1"; shift
 
-  # pick strategy
   if command -v stdbuf >/dev/null 2>&1; then
-    # Linux: force line buffering
     stdbuf -oL -eL "$@" 2>&1 | awk -v p="$prefix" '{ print p " " $0; fflush(); }'
   elif command -v script >/dev/null 2>&1; then
-    # cross-platform fallback (macOS, etc.)
     script -q /dev/null "$@" 2>&1 | awk -v p="$prefix" '{ print p " " $0; fflush(); }'
   else
-    # last resort (no buffering guarantees)
     "$@" 2>&1 | awk -v p="$prefix" '{ print p " " $0; fflush(); }'
   fi
 }
@@ -67,18 +63,18 @@ fi
 
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 FEATURE_ROOT="${REPO_ROOT}/features/default"
-DOTFILES_SOURCE_PATH="${REPO_ROOT}/home"
+HOME_PAYLOAD_PATH="${REPO_ROOT}/home"
 INITIAL_FILES_SOURCE_PATH="${REPO_ROOT}/initial-files"
 DOTFILES_STATE_PATH="${HOME}/.dotfiles"
 BACKUP_PATH="${DOTFILES_STATE_PATH}/backups"
-CODEX_SOURCE_PATH="${DOTFILES_SOURCE_PATH}/.codex"
+CODEX_SOURCE_PATH="${HOME_PAYLOAD_PATH}/.codex"
 CODEX_TARGET_PATH="${HOME}/.codex"
 RULESY_BIN="${HOME}/bin/rulesy"
 DOF_RULESY_BIN="${HOME}/.dof/bin/rulesy"
 RULESY_INSTALL_URL="https://raw.githubusercontent.com/notwillk/rulesy/main/scripts/install.sh"
 
-if [[ ! -d "${DOTFILES_SOURCE_PATH}" ]]; then
-  log "Expected Stow package directory '${DOTFILES_SOURCE_PATH}' does not exist." >&2
+if [[ ! -d "${HOME_PAYLOAD_PATH}" ]]; then
+  log "Expected home payload directory '${HOME_PAYLOAD_PATH}' does not exist." >&2
   exit 1
 fi
 
@@ -220,93 +216,6 @@ copy_initial_files() {
   done < <(find "${INITIAL_FILES_SOURCE_PATH}" -type f -print0 | sort -z)
 }
 
-if command -v stow >/dev/null 2>&1; then
-  log "GNU Stow is installed: $(command -v stow)"
-else
-  SUDO=()
-
-  require_sudo() {
-    if [[ "${EUID:-$(id -u)}" -eq 0 ]]; then
-      SUDO=()
-    elif command -v sudo >/dev/null 2>&1; then
-      SUDO=(sudo)
-    else
-      log "GNU Stow is not installed, and sudo is unavailable." >&2
-      log "Please install GNU Stow manually or run this script as root." >&2
-      exit 1
-    fi
-  }
-
-  install_with() {
-    local manager="$1"
-
-    log "GNU Stow is not installed. Installing with ${manager}..."
-
-    case "${manager}" in
-      brew)
-        brew install stow
-        ;;
-      apt-get)
-        require_sudo
-        "${SUDO[@]}" apt-get update
-        "${SUDO[@]}" apt-get install -y stow
-        ;;
-      apt)
-        require_sudo
-        "${SUDO[@]}" apt update
-        "${SUDO[@]}" apt install -y stow
-        ;;
-      dnf)
-        require_sudo
-        "${SUDO[@]}" dnf install -y stow
-        ;;
-      yum)
-        require_sudo
-        "${SUDO[@]}" yum install -y stow
-        ;;
-      pacman)
-        require_sudo
-        "${SUDO[@]}" pacman -Sy --noconfirm stow
-        ;;
-      zypper)
-        require_sudo
-        "${SUDO[@]}" zypper --non-interactive install stow
-        ;;
-      apk)
-        require_sudo
-        "${SUDO[@]}" apk add stow
-        ;;
-      xbps-install)
-        require_sudo
-        "${SUDO[@]}" xbps-install -Sy stow
-        ;;
-      pkg)
-        require_sudo
-        "${SUDO[@]}" pkg install -y stow
-        ;;
-      *)
-        log "Unsupported package manager: ${manager}" >&2
-        exit 1
-        ;;
-    esac
-  }
-
-  for manager in brew apt-get apt dnf yum pacman zypper apk xbps-install pkg; do
-    if command -v "${manager}" >/dev/null 2>&1; then
-      install_with "${manager}"
-      break
-    fi
-  done
-
-  if ! command -v stow >/dev/null 2>&1; then
-    log "Failed to install GNU Stow." >&2
-    log "Supported managers: brew, apt-get, apt, dnf, yum, pacman, zypper, apk, xbps-install, pkg." >&2
-    exit 1
-  fi
-
-  log "GNU Stow installed: $(command -v stow)"
-fi
-
 install_rulesy
 install_rulesy_for_dof
 
@@ -315,97 +224,11 @@ install_rulesy_for_dof
   check \
   --fix
 
-resolve_link_target() {
-  local link_path="$1"
-  local link_target
-  local candidate
-  local candidate_dir
-
-  link_target="$(readlink "${link_path}")"
-  if [[ "${link_target}" = /* ]]; then
-    candidate="${link_target}"
-  else
-    candidate="$(dirname "${link_path}")/${link_target}"
-  fi
-
-  candidate_dir="$(cd -P "$(dirname "${candidate}")" 2>/dev/null && pwd)" || return 1
-  printf '%s/%s\n' "${candidate_dir}" "$(basename "${candidate}")"
-}
-
-handoff_legacy_checkout() {
-  local marker="${HOME}/managed_by_dofiles.md"
-  local current_marker="${DOTFILES_SOURCE_PATH}/managed_by_dofiles.md"
-  local legacy_marker
-  local legacy_root
-  local legacy_codex_source
-  local codex_target="${CODEX_TARGET_PATH}/config.toml"
-  local codex_source=""
-
-  if [[ ! -L "${marker}" ]]; then
-    return
-  fi
-
-  legacy_marker="$(resolve_link_target "${marker}")" || {
-    log "CRITICAL: Cannot resolve legacy marker link '${marker}'; refusing to alter it." >&2
-    return 1
-  }
-
-  if [[ "${legacy_marker}" == "${current_marker}" ]]; then
-    return
-  fi
-
-  if [[ "${legacy_marker}" != */home/managed_by_dofiles.md ]]; then
-    log "CRITICAL: Marker '${marker}' points outside a recognizable dotfiles checkout: '${legacy_marker}'." >&2
-    log "Remove or migrate that link manually before retrying dof apply." >&2
-    return 1
-  fi
-
-  legacy_root="${legacy_marker%/home/managed_by_dofiles.md}"
-  if [[ ! -d "${legacy_root}/home" || ! -f "${legacy_marker}" ]]; then
-    log "CRITICAL: Legacy checkout '${legacy_root}' is incomplete; refusing automatic handoff." >&2
-    return 1
-  fi
-
-  log "Handing off Stow links from legacy checkout '${legacy_root}'."
-
-  prepend "[stow:legacy]" stow \
-    "--verbose=${STOW_VERBOSITY:-${VERBOCITY:-1}}" \
-    --delete \
-    --dir "${legacy_root}" \
-    --target "${HOME}" \
-    home
-
-  if [[ -L "${codex_target}" ]]; then
-    codex_source="$(resolve_link_target "${codex_target}" || true)"
-    legacy_codex_source="${legacy_root}/home/.codex/config.toml"
-    if [[ "${codex_source}" == "${legacy_codex_source}" ]]; then
-      rm "${codex_target}"
-      log "Removed legacy Codex config link: ${codex_target}"
-    fi
-  fi
-}
-
 GIT_PATH="git@github.com:notwillk/dotfiles.git"
 
-STOW_PACKAGE="${DOTFILES_SOURCE_PATH#"${REPO_ROOT}/"}"
-STOW_VERBOSITY="${STOW_VERBOSITY:-${VERBOCITY:-1}}"
-STOW_COMMAND=(
-  stow
-  "--verbose=${STOW_VERBOSITY}"
-  --restow
-  --dir "${REPO_ROOT}"
-  --target "${HOME}"
-  "${STOW_PACKAGE}"
-)
-
 mkdir -p "${DOTFILES_STATE_PATH}" "${BACKUP_PATH}"
-handoff_legacy_checkout
 copy_initial_files
-log "Linking '${DOTFILES_SOURCE_PATH}' into '${HOME}'..."
-printf -v STOW_COMMAND_DISPLAY "%q " "${STOW_COMMAND[@]}"
-log "Running \`${STOW_COMMAND_DISPLAY% }\`..."
-prepend "[stow]" "${STOW_COMMAND[@]}"
 link_codex_config
-log "Dotfiles successfully linked from the dof workspace."
+log "Dotfiles successfully reconciled from the dof workspace."
 log "Make updates in ${REPO_ROOT} and push them to ${GIT_PATH}."
 log "Uninstall links by running \`${REPO_ROOT}/uninstall.sh\`."

--- a/features/default/gpg.rulesy.yaml
+++ b/features/default/gpg.rulesy.yaml
@@ -214,3 +214,7 @@ rules:
         fi
       }
       run_privileged pkg install -y gnupg
+
+  - name: GPG is available
+    check: command -v gpg >/dev/null 2>&1
+    hint: Install GPG with Homebrew or another supported system package manager.

--- a/features/default/home-files.rulesy.yaml
+++ b/features/default/home-files.rulesy.yaml
@@ -1,0 +1,7 @@
+rules:
+  - name: Home files are linked from the active dof workspace
+    skip-if: |
+      ! command -v gpg >/dev/null 2>&1 ||
+        ! command -v stow >/dev/null 2>&1
+    check: ./scripts/stow-home-files check
+    fix: ./scripts/stow-home-files apply

--- a/features/default/rulesy.yaml
+++ b/features/default/rulesy.yaml
@@ -1,2 +1,4 @@
 rules:
   - remote: gpg.rulesy.yaml
+  - remote: stow.rulesy.yaml
+  - remote: home-files.rulesy.yaml

--- a/features/default/scripts/stow-home-files
+++ b/features/default/scripts/stow-home-files
@@ -1,0 +1,222 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+log() {
+  printf '[stow-home-files] %s\n' "$*"
+}
+
+fail() {
+  log "$*" >&2
+  return 1
+}
+
+if [[ -z "${HOME:-}" ]]; then
+  fail "HOME is not set; refusing to manage an unknown target directory."
+  exit 1
+fi
+
+if [[ ! -d "${HOME}" ]]; then
+  fail "HOME is set to '${HOME}', but that directory does not exist."
+  exit 1
+fi
+
+FEATURE_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd -P)"
+REPO_ROOT="$(cd "${FEATURE_ROOT}/../.." && pwd -P)"
+HOME_PACKAGE_PATH="${REPO_ROOT}/home"
+MARKER_PATH="${HOME}/managed_by_dofiles.md"
+CURRENT_MARKER_PATH="${HOME_PACKAGE_PATH}/managed_by_dofiles.md"
+CODEX_TARGET_PATH="${HOME}/.codex/config.toml"
+STOW_VERBOSITY="${STOW_VERBOSITY:-${VERBOCITY:-}}"
+
+if [[ ! -d "${HOME_PACKAGE_PATH}" ]]; then
+  fail "Expected home package directory '${HOME_PACKAGE_PATH}' does not exist."
+  exit 1
+fi
+
+if ! command -v stow >/dev/null 2>&1; then
+  fail "GNU Stow is not installed. Run '${HOME}/.dof/bin/dof apply' to install it."
+  exit 1
+fi
+
+resolve_link_target() {
+  local link_path="$1"
+  local link_target
+  local candidate
+  local candidate_dir
+
+  link_target="$(readlink "${link_path}")"
+  if [[ "${link_target}" = /* ]]; then
+    candidate="${link_target}"
+  else
+    candidate="$(dirname "${link_path}")/${link_target}"
+  fi
+
+  candidate_dir="$(cd -P "$(dirname "${candidate}")" 2>/dev/null && pwd)" || return 1
+  printf '%s/%s\n' "${candidate_dir}" "$(basename "${candidate}")"
+}
+
+canonical_leaf_path() {
+  local path="$1"
+  local path_dir
+
+  path_dir="$(cd -P "$(dirname "${path}")" 2>/dev/null && pwd)" || return 1
+  printf '%s/%s\n' "${path_dir}" "$(basename "${path}")"
+}
+
+validate_marker_ownership() {
+  local current_marker
+  local installed_marker
+  local legacy_root
+
+  if [[ ! -L "${MARKER_PATH}" ]]; then
+    return
+  fi
+
+  installed_marker="$(resolve_link_target "${MARKER_PATH}")" || {
+    fail "CRITICAL: Cannot resolve marker link '${MARKER_PATH}'; refusing to alter it."
+    return 1
+  }
+  current_marker="$(canonical_leaf_path "${CURRENT_MARKER_PATH}")" || {
+    fail "CRITICAL: Cannot resolve the active workspace marker '${CURRENT_MARKER_PATH}'."
+    return 1
+  }
+
+  if [[ "${installed_marker}" == "${current_marker}" ]]; then
+    return
+  fi
+
+  if [[ "${installed_marker}" != */home/managed_by_dofiles.md ]]; then
+    fail "CRITICAL: Marker '${MARKER_PATH}' points outside a recognizable dotfiles checkout: '${installed_marker}'."
+    fail "Remove or migrate that link manually before retrying dof apply."
+    return 1
+  fi
+
+  legacy_root="${installed_marker%/home/managed_by_dofiles.md}"
+  if [[ "${legacy_root}" == "${REPO_ROOT}" || ! -d "${legacy_root}/home" || ! -f "${installed_marker}" ]]; then
+    fail "CRITICAL: Legacy checkout '${legacy_root}' is incomplete or ambiguous; refusing automatic handoff."
+    return 1
+  fi
+}
+
+handoff_legacy_checkout() {
+  local current_marker
+  local installed_marker
+  local legacy_codex_source
+  local legacy_root
+  local installed_codex_source=""
+
+  if [[ ! -L "${MARKER_PATH}" ]]; then
+    return
+  fi
+
+  validate_marker_ownership
+  installed_marker="$(resolve_link_target "${MARKER_PATH}")"
+  current_marker="$(canonical_leaf_path "${CURRENT_MARKER_PATH}")"
+
+  if [[ "${installed_marker}" == "${current_marker}" ]]; then
+    return
+  fi
+
+  legacy_root="${installed_marker%/home/managed_by_dofiles.md}"
+  log "Handing off links from legacy checkout '${legacy_root}'."
+  stow \
+    "--verbose=${STOW_VERBOSITY:-1}" \
+    --delete \
+    --dir "${legacy_root}" \
+    --target "${HOME}" \
+    home
+
+  if [[ -L "${CODEX_TARGET_PATH}" ]]; then
+    installed_codex_source="$(resolve_link_target "${CODEX_TARGET_PATH}" || true)"
+    legacy_codex_source="${legacy_root}/home/.codex/config.toml"
+    if [[ "${installed_codex_source}" == "${legacy_codex_source}" ]]; then
+      rm "${CODEX_TARGET_PATH}"
+      log "Removed legacy Codex config link: ${CODEX_TARGET_PATH}"
+    fi
+  fi
+}
+
+check_home_files() {
+  local action_output
+  local output
+  local status
+
+  validate_marker_ownership
+
+  set +e
+  output="$(
+    stow \
+      "--verbose=${STOW_VERBOSITY:-1}" \
+      --simulate \
+      --stow \
+      --dir "${REPO_ROOT}" \
+      --target "${HOME}" \
+      home 2>&1
+  )"
+  status="$?"
+  set -e
+
+  if [[ -n "${output}" ]]; then
+    while IFS= read -r line; do
+      printf '[stow] %s\n' "${line}"
+    done <<<"${output}"
+  fi
+
+  if [[ "${status}" -ne 0 ]]; then
+    fail "GNU Stow reported an error while checking the home package."
+    return "${status}"
+  fi
+
+  action_output="$(
+    printf '%s\n' "${output}" |
+      awk '$0 != "WARNING: in simulation mode so not modifying filesystem."'
+  )"
+  if [[ -n "${action_output}" ]]; then
+    fail "Home files are not fully linked; the simulation above shows pending changes."
+    return 1
+  fi
+
+  log "Home files are linked from '${HOME_PACKAGE_PATH}'."
+}
+
+apply_home_files() {
+  handoff_legacy_checkout
+  log "Reconciling '${HOME_PACKAGE_PATH}' into '${HOME}'."
+  stow \
+    "--verbose=${STOW_VERBOSITY:-1}" \
+    --restow \
+    --dir "${REPO_ROOT}" \
+    --target "${HOME}" \
+    home
+}
+
+uninstall_home_files() {
+  log "Removing links owned by '${HOME_PACKAGE_PATH}' from '${HOME}'."
+  stow \
+    "--verbose=${STOW_VERBOSITY:-2}" \
+    --delete \
+    --dir "${REPO_ROOT}" \
+    --target "${HOME}" \
+    home
+}
+
+if [[ "$#" -ne 1 ]]; then
+  fail "Usage: $0 check|apply|uninstall"
+  exit 2
+fi
+
+case "$1" in
+  check)
+    check_home_files
+    ;;
+  apply)
+    apply_home_files
+    ;;
+  uninstall)
+    uninstall_home_files
+    ;;
+  *)
+    fail "Unknown operation '$1'; expected check, apply, or uninstall."
+    exit 2
+    ;;
+esac

--- a/features/default/scripts/stow-home-files
+++ b/features/default/scripts/stow-home-files
@@ -86,8 +86,8 @@ validate_marker_ownership() {
   fi
 
   if [[ "${installed_marker}" != */home/managed_by_dofiles.md ]]; then
-    fail "CRITICAL: Marker '${MARKER_PATH}' points outside a recognizable dotfiles checkout: '${installed_marker}'."
-    fail "Remove or migrate that link manually before retrying dof apply."
+    log "CRITICAL: Marker '${MARKER_PATH}' points outside a recognizable dotfiles checkout: '${installed_marker}'." >&2
+    log "Remove or migrate that link manually before retrying dof apply." >&2
     return 1
   fi
 

--- a/features/default/stow.rulesy.yaml
+++ b/features/default/stow.rulesy.yaml
@@ -1,0 +1,300 @@
+rules:
+  - name: GNU Stow is installed with Homebrew
+    skip-if: |
+      command -v stow >/dev/null 2>&1 ||
+        ! command -v brew >/dev/null 2>&1
+    check: command -v stow >/dev/null 2>&1
+    fix: brew install stow
+
+  - name: GNU Stow is installed with apt-get as root
+    skip-if: |
+      command -v stow >/dev/null 2>&1 ||
+        command -v brew >/dev/null 2>&1 ||
+        ! command -v apt-get >/dev/null 2>&1 ||
+        [[ "${EUID:-$(id -u)}" -ne 0 ]]
+    check: command -v stow >/dev/null 2>&1
+    fix: |
+      set -e
+      apt-get update
+      apt-get install -y stow
+
+  - name: GNU Stow is installed with apt-get using sudo
+    skip-if: |
+      command -v stow >/dev/null 2>&1 ||
+        command -v brew >/dev/null 2>&1 ||
+        ! command -v apt-get >/dev/null 2>&1 ||
+        [[ "${EUID:-$(id -u)}" -eq 0 ]]
+    check: command -v stow >/dev/null 2>&1
+    interactive-fix: |
+      set -e
+      if ! command -v sudo >/dev/null 2>&1; then
+        printf 'GNU Stow installation requires root or sudo.\n' >&2
+        exit 1
+      fi
+      sudo apt-get update
+      sudo apt-get install -y stow
+
+  - name: GNU Stow is installed with apt as root
+    skip-if: |
+      command -v stow >/dev/null 2>&1 ||
+        command -v brew >/dev/null 2>&1 ||
+        command -v apt-get >/dev/null 2>&1 ||
+        ! command -v apt >/dev/null 2>&1 ||
+        [[ "${EUID:-$(id -u)}" -ne 0 ]]
+    check: command -v stow >/dev/null 2>&1
+    fix: |
+      set -e
+      apt update
+      apt install -y stow
+
+  - name: GNU Stow is installed with apt using sudo
+    skip-if: |
+      command -v stow >/dev/null 2>&1 ||
+        command -v brew >/dev/null 2>&1 ||
+        command -v apt-get >/dev/null 2>&1 ||
+        ! command -v apt >/dev/null 2>&1 ||
+        [[ "${EUID:-$(id -u)}" -eq 0 ]]
+    check: command -v stow >/dev/null 2>&1
+    interactive-fix: |
+      set -e
+      if ! command -v sudo >/dev/null 2>&1; then
+        printf 'GNU Stow installation requires root or sudo.\n' >&2
+        exit 1
+      fi
+      sudo apt update
+      sudo apt install -y stow
+
+  - name: GNU Stow is installed with dnf as root
+    skip-if: |
+      command -v stow >/dev/null 2>&1 ||
+        command -v brew >/dev/null 2>&1 ||
+        command -v apt-get >/dev/null 2>&1 ||
+        command -v apt >/dev/null 2>&1 ||
+        ! command -v dnf >/dev/null 2>&1 ||
+        [[ "${EUID:-$(id -u)}" -ne 0 ]]
+    check: command -v stow >/dev/null 2>&1
+    fix: dnf install -y stow
+
+  - name: GNU Stow is installed with dnf using sudo
+    skip-if: |
+      command -v stow >/dev/null 2>&1 ||
+        command -v brew >/dev/null 2>&1 ||
+        command -v apt-get >/dev/null 2>&1 ||
+        command -v apt >/dev/null 2>&1 ||
+        ! command -v dnf >/dev/null 2>&1 ||
+        [[ "${EUID:-$(id -u)}" -eq 0 ]]
+    check: command -v stow >/dev/null 2>&1
+    interactive-fix: |
+      if ! command -v sudo >/dev/null 2>&1; then
+        printf 'GNU Stow installation requires root or sudo.\n' >&2
+        exit 1
+      fi
+      sudo dnf install -y stow
+
+  - name: GNU Stow is installed with yum as root
+    skip-if: |
+      command -v stow >/dev/null 2>&1 ||
+        command -v brew >/dev/null 2>&1 ||
+        command -v apt-get >/dev/null 2>&1 ||
+        command -v apt >/dev/null 2>&1 ||
+        command -v dnf >/dev/null 2>&1 ||
+        ! command -v yum >/dev/null 2>&1 ||
+        [[ "${EUID:-$(id -u)}" -ne 0 ]]
+    check: command -v stow >/dev/null 2>&1
+    fix: yum install -y stow
+
+  - name: GNU Stow is installed with yum using sudo
+    skip-if: |
+      command -v stow >/dev/null 2>&1 ||
+        command -v brew >/dev/null 2>&1 ||
+        command -v apt-get >/dev/null 2>&1 ||
+        command -v apt >/dev/null 2>&1 ||
+        command -v dnf >/dev/null 2>&1 ||
+        ! command -v yum >/dev/null 2>&1 ||
+        [[ "${EUID:-$(id -u)}" -eq 0 ]]
+    check: command -v stow >/dev/null 2>&1
+    interactive-fix: |
+      if ! command -v sudo >/dev/null 2>&1; then
+        printf 'GNU Stow installation requires root or sudo.\n' >&2
+        exit 1
+      fi
+      sudo yum install -y stow
+
+  - name: GNU Stow is installed with pacman as root
+    skip-if: |
+      command -v stow >/dev/null 2>&1 ||
+        command -v brew >/dev/null 2>&1 ||
+        command -v apt-get >/dev/null 2>&1 ||
+        command -v apt >/dev/null 2>&1 ||
+        command -v dnf >/dev/null 2>&1 ||
+        command -v yum >/dev/null 2>&1 ||
+        ! command -v pacman >/dev/null 2>&1 ||
+        [[ "${EUID:-$(id -u)}" -ne 0 ]]
+    check: command -v stow >/dev/null 2>&1
+    fix: pacman -Sy --noconfirm stow
+
+  - name: GNU Stow is installed with pacman using sudo
+    skip-if: |
+      command -v stow >/dev/null 2>&1 ||
+        command -v brew >/dev/null 2>&1 ||
+        command -v apt-get >/dev/null 2>&1 ||
+        command -v apt >/dev/null 2>&1 ||
+        command -v dnf >/dev/null 2>&1 ||
+        command -v yum >/dev/null 2>&1 ||
+        ! command -v pacman >/dev/null 2>&1 ||
+        [[ "${EUID:-$(id -u)}" -eq 0 ]]
+    check: command -v stow >/dev/null 2>&1
+    interactive-fix: |
+      if ! command -v sudo >/dev/null 2>&1; then
+        printf 'GNU Stow installation requires root or sudo.\n' >&2
+        exit 1
+      fi
+      sudo pacman -Sy --noconfirm stow
+
+  - name: GNU Stow is installed with zypper as root
+    skip-if: |
+      command -v stow >/dev/null 2>&1 ||
+        command -v brew >/dev/null 2>&1 ||
+        command -v apt-get >/dev/null 2>&1 ||
+        command -v apt >/dev/null 2>&1 ||
+        command -v dnf >/dev/null 2>&1 ||
+        command -v yum >/dev/null 2>&1 ||
+        command -v pacman >/dev/null 2>&1 ||
+        ! command -v zypper >/dev/null 2>&1 ||
+        [[ "${EUID:-$(id -u)}" -ne 0 ]]
+    check: command -v stow >/dev/null 2>&1
+    fix: zypper --non-interactive install stow
+
+  - name: GNU Stow is installed with zypper using sudo
+    skip-if: |
+      command -v stow >/dev/null 2>&1 ||
+        command -v brew >/dev/null 2>&1 ||
+        command -v apt-get >/dev/null 2>&1 ||
+        command -v apt >/dev/null 2>&1 ||
+        command -v dnf >/dev/null 2>&1 ||
+        command -v yum >/dev/null 2>&1 ||
+        command -v pacman >/dev/null 2>&1 ||
+        ! command -v zypper >/dev/null 2>&1 ||
+        [[ "${EUID:-$(id -u)}" -eq 0 ]]
+    check: command -v stow >/dev/null 2>&1
+    interactive-fix: |
+      if ! command -v sudo >/dev/null 2>&1; then
+        printf 'GNU Stow installation requires root or sudo.\n' >&2
+        exit 1
+      fi
+      sudo zypper --non-interactive install stow
+
+  - name: GNU Stow is installed with apk as root
+    skip-if: |
+      command -v stow >/dev/null 2>&1 ||
+        command -v brew >/dev/null 2>&1 ||
+        command -v apt-get >/dev/null 2>&1 ||
+        command -v apt >/dev/null 2>&1 ||
+        command -v dnf >/dev/null 2>&1 ||
+        command -v yum >/dev/null 2>&1 ||
+        command -v pacman >/dev/null 2>&1 ||
+        command -v zypper >/dev/null 2>&1 ||
+        ! command -v apk >/dev/null 2>&1 ||
+        [[ "${EUID:-$(id -u)}" -ne 0 ]]
+    check: command -v stow >/dev/null 2>&1
+    fix: apk add stow
+
+  - name: GNU Stow is installed with apk using sudo
+    skip-if: |
+      command -v stow >/dev/null 2>&1 ||
+        command -v brew >/dev/null 2>&1 ||
+        command -v apt-get >/dev/null 2>&1 ||
+        command -v apt >/dev/null 2>&1 ||
+        command -v dnf >/dev/null 2>&1 ||
+        command -v yum >/dev/null 2>&1 ||
+        command -v pacman >/dev/null 2>&1 ||
+        command -v zypper >/dev/null 2>&1 ||
+        ! command -v apk >/dev/null 2>&1 ||
+        [[ "${EUID:-$(id -u)}" -eq 0 ]]
+    check: command -v stow >/dev/null 2>&1
+    interactive-fix: |
+      if ! command -v sudo >/dev/null 2>&1; then
+        printf 'GNU Stow installation requires root or sudo.\n' >&2
+        exit 1
+      fi
+      sudo apk add stow
+
+  - name: GNU Stow is installed with xbps-install as root
+    skip-if: |
+      command -v stow >/dev/null 2>&1 ||
+        command -v brew >/dev/null 2>&1 ||
+        command -v apt-get >/dev/null 2>&1 ||
+        command -v apt >/dev/null 2>&1 ||
+        command -v dnf >/dev/null 2>&1 ||
+        command -v yum >/dev/null 2>&1 ||
+        command -v pacman >/dev/null 2>&1 ||
+        command -v zypper >/dev/null 2>&1 ||
+        command -v apk >/dev/null 2>&1 ||
+        ! command -v xbps-install >/dev/null 2>&1 ||
+        [[ "${EUID:-$(id -u)}" -ne 0 ]]
+    check: command -v stow >/dev/null 2>&1
+    fix: xbps-install -Sy stow
+
+  - name: GNU Stow is installed with xbps-install using sudo
+    skip-if: |
+      command -v stow >/dev/null 2>&1 ||
+        command -v brew >/dev/null 2>&1 ||
+        command -v apt-get >/dev/null 2>&1 ||
+        command -v apt >/dev/null 2>&1 ||
+        command -v dnf >/dev/null 2>&1 ||
+        command -v yum >/dev/null 2>&1 ||
+        command -v pacman >/dev/null 2>&1 ||
+        command -v zypper >/dev/null 2>&1 ||
+        command -v apk >/dev/null 2>&1 ||
+        ! command -v xbps-install >/dev/null 2>&1 ||
+        [[ "${EUID:-$(id -u)}" -eq 0 ]]
+    check: command -v stow >/dev/null 2>&1
+    interactive-fix: |
+      if ! command -v sudo >/dev/null 2>&1; then
+        printf 'GNU Stow installation requires root or sudo.\n' >&2
+        exit 1
+      fi
+      sudo xbps-install -Sy stow
+
+  - name: GNU Stow is installed with pkg as root
+    skip-if: |
+      command -v stow >/dev/null 2>&1 ||
+        command -v brew >/dev/null 2>&1 ||
+        command -v apt-get >/dev/null 2>&1 ||
+        command -v apt >/dev/null 2>&1 ||
+        command -v dnf >/dev/null 2>&1 ||
+        command -v yum >/dev/null 2>&1 ||
+        command -v pacman >/dev/null 2>&1 ||
+        command -v zypper >/dev/null 2>&1 ||
+        command -v apk >/dev/null 2>&1 ||
+        command -v xbps-install >/dev/null 2>&1 ||
+        ! command -v pkg >/dev/null 2>&1 ||
+        [[ "${EUID:-$(id -u)}" -ne 0 ]]
+    check: command -v stow >/dev/null 2>&1
+    fix: pkg install -y stow
+
+  - name: GNU Stow is installed with pkg using sudo
+    skip-if: |
+      command -v stow >/dev/null 2>&1 ||
+        command -v brew >/dev/null 2>&1 ||
+        command -v apt-get >/dev/null 2>&1 ||
+        command -v apt >/dev/null 2>&1 ||
+        command -v dnf >/dev/null 2>&1 ||
+        command -v yum >/dev/null 2>&1 ||
+        command -v pacman >/dev/null 2>&1 ||
+        command -v zypper >/dev/null 2>&1 ||
+        command -v apk >/dev/null 2>&1 ||
+        command -v xbps-install >/dev/null 2>&1 ||
+        ! command -v pkg >/dev/null 2>&1 ||
+        [[ "${EUID:-$(id -u)}" -eq 0 ]]
+    check: command -v stow >/dev/null 2>&1
+    interactive-fix: |
+      if ! command -v sudo >/dev/null 2>&1; then
+        printf 'GNU Stow installation requires root or sudo.\n' >&2
+        exit 1
+      fi
+      sudo pkg install -y stow
+
+  - name: GNU Stow is available
+    check: command -v stow >/dev/null 2>&1
+    hint: Install GNU Stow with Homebrew or another supported system package manager.

--- a/home/managed_by_dofiles.md
+++ b/home/managed_by_dofiles.md
@@ -30,9 +30,11 @@ git -C "$HOME/.dof/workspace" pull --ff-only
 "$HOME/.dof/workspace/verify.sh"
 ```
 
-The default dof feature installs GNU Stow and `$HOME/bin/rulesy` when needed,
-preserves backups under `$HOME/.dotfiles/backups`, copies the initial
-entrypoint files, and refreshes managed links. Reapplying is supported.
+The default dof feature installs `$HOME/bin/rulesy` when needed. Rulesy then
+installs GPG and GNU Stow, verifies the complete home package, and refreshes
+managed links through the shared lifecycle helper. The feature preserves
+backups under `$HOME/.dotfiles/backups`, copies the initial entrypoint files,
+and manages the separate Codex config link. Reapplying is supported.
 
 On macOS, the `macos-gui` feature uses Rulesy to install Homebrew, append its
 desired formula, casks, and App Store entries to `$HOME/.Brewfile`, and

--- a/tests/60-alpine-apk.Dockerfile
+++ b/tests/60-alpine-apk.Dockerfile
@@ -1,6 +1,6 @@
 FROM alpine:3.20
 
-RUN apk add --no-cache bash stow \
+RUN apk add --no-cache bash gnupg stow \
   && mkdir -p /opt/test-stow \
   && cp "$(command -v stow)" /opt/test-stow/stow \
   && rm -f "$(command -v stow)"

--- a/tests/home-files-helper-integration.sh
+++ b/tests/home-files-helper-integration.sh
@@ -16,7 +16,9 @@ command -v stow >/dev/null 2>&1 || fail "GNU Stow is required"
 
 home="${TEST_ROOT}/home"
 conflict_home="${TEST_ROOT}/conflict-home"
-mkdir -p "${home}" "${conflict_home}"
+ambiguous_home="${TEST_ROOT}/ambiguous-home"
+foreign_marker="${TEST_ROOT}/foreign/marker"
+mkdir -p "${home}" "${conflict_home}" "${ambiguous_home}" "$(dirname "${foreign_marker}")"
 
 HOME="${home}" "${HELPER}" apply
 HOME="${home}" "${HELPER}" check
@@ -42,5 +44,19 @@ if HOME="${conflict_home}" "${HELPER}" apply; then
 fi
 [[ "$(cat "${conflict_home}/managed_by_dofiles.md")" == "unmanaged" ]] ||
   fail "helper apply changed an unmanaged conflict"
+
+printf 'foreign\n' >"${foreign_marker}"
+ln -s "${foreign_marker}" "${ambiguous_home}/managed_by_dofiles.md"
+if ambiguous_output="$(HOME="${ambiguous_home}" "${HELPER}" apply 2>&1)"; then
+  fail "helper apply accepted an ambiguous legacy marker"
+fi
+grep -Fq "points outside a recognizable dotfiles checkout" <<<"${ambiguous_output}" ||
+  fail "ambiguous marker failure omitted the ownership diagnostic"
+grep -Fq "Remove or migrate that link manually before retrying dof apply." <<<"${ambiguous_output}" ||
+  fail "ambiguous marker failure omitted the recovery guidance"
+[[ -L "${ambiguous_home}/managed_by_dofiles.md" ]] ||
+  fail "helper apply removed an ambiguous legacy marker"
+[[ "$(readlink "${ambiguous_home}/managed_by_dofiles.md")" == "${foreign_marker}" ]] ||
+  fail "helper apply changed an ambiguous legacy marker"
 
 printf '[tests/home-files-helper-integration.sh] Shared helper lifecycle passed.\n'

--- a/tests/home-files-helper-integration.sh
+++ b/tests/home-files-helper-integration.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+REPO_ROOT="${1:-$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)}"
+HELPER="${REPO_ROOT}/features/default/scripts/stow-home-files"
+TEST_ROOT="$(mktemp -d "${TMPDIR:-/tmp}/dotfiles-home-files-helper.XXXXXX")"
+trap 'rm -rf "${TEST_ROOT}"' EXIT
+
+fail() {
+  printf '[tests/home-files-helper-integration.sh] %s\n' "$*" >&2
+  exit 1
+}
+
+[[ -x "${HELPER}" ]] || fail "shared helper is not executable: ${HELPER}"
+command -v stow >/dev/null 2>&1 || fail "GNU Stow is required"
+
+home="${TEST_ROOT}/home"
+conflict_home="${TEST_ROOT}/conflict-home"
+mkdir -p "${home}" "${conflict_home}"
+
+HOME="${home}" "${HELPER}" apply
+HOME="${home}" "${HELPER}" check
+[[ -L "${home}/managed_by_dofiles.md" ]] ||
+  fail "helper apply did not create the managed marker"
+[[ "$(readlink "${home}/managed_by_dofiles.md")" == *"/home/managed_by_dofiles.md" ]] ||
+  fail "managed marker does not point into the home package"
+
+unlink "${home}/managed_by_dofiles.md"
+if HOME="${home}" "${HELPER}" check; then
+  fail "helper check did not detect a missing managed link"
+fi
+HOME="${home}" "${HELPER}" apply
+HOME="${home}" "${HELPER}" check
+
+HOME="${home}" "${HELPER}" uninstall
+[[ ! -e "${home}/managed_by_dofiles.md" && ! -L "${home}/managed_by_dofiles.md" ]] ||
+  fail "helper uninstall left the managed marker"
+
+printf 'unmanaged\n' >"${conflict_home}/managed_by_dofiles.md"
+if HOME="${conflict_home}" "${HELPER}" apply; then
+  fail "helper apply overwrote an unmanaged conflict"
+fi
+[[ "$(cat "${conflict_home}/managed_by_dofiles.md")" == "unmanaged" ]] ||
+  fail "helper apply changed an unmanaged conflict"
+
+printf '[tests/home-files-helper-integration.sh] Shared helper lifecycle passed.\n'

--- a/tests/integration.sh
+++ b/tests/integration.sh
@@ -4,6 +4,8 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
 DOF_BIN="${DOF_BIN:-$(command -v dof || true)}"
+RULESY_BIN="${RULESY_BIN:-$(command -v rulesy || true)}"
+export RULESY_TEST_BIN="${RULESY_BIN}"
 
 fail() {
   printf '[tests/integration.sh] %s\n' "$*" >&2
@@ -11,6 +13,7 @@ fail() {
 }
 
 [[ -x "${DOF_BIN}" ]] || fail "dof is required"
+[[ -x "${RULESY_BIN}" ]] || fail "Rulesy is required"
 command -v git >/dev/null 2>&1 || fail "git is required"
 command -v stow >/dev/null 2>&1 || fail "GNU Stow is required"
 
@@ -54,6 +57,7 @@ case "$*" in
     fi
     ;;
 esac
+exec "${RULESY_TEST_BIN}" "$@"
 RULESY
   chmod 0755 "${home}/bin/rulesy"
 }
@@ -201,14 +205,16 @@ run_default_rulesy_contract_test() {
   local expected_command
   local -a prior_managers=()
 
-  [[ "$(cat "${main_config}")" == $'rules:\n  - remote: gpg.rulesy.yaml' ]] ||
-    fail "default rulesy.yaml must contain only the GPG remote"
+  [[ "$(cat "${main_config}")" == $'rules:\n  - remote: gpg.rulesy.yaml\n  - remote: stow.rulesy.yaml\n  - remote: home-files.rulesy.yaml' ]] ||
+    fail "default rulesy.yaml must contain only the ordered GPG, Stow, and home-files remotes"
   [[ "$(grep -c '^  - name: GPG is installed with ' "${config}")" -eq 10 ]] ||
     fail "GPG configuration does not contain exactly ten installer rules"
-  [[ "$(grep -c '^    check: command -v gpg >/dev/null 2>&1$' "${config}")" -eq 10 ]] ||
-    fail "every GPG installer rule must check the exact gpg executable"
+  [[ "$(grep -c '^    check: command -v gpg >/dev/null 2>&1$' "${config}")" -eq 11 ]] ||
+    fail "every GPG installer and the final invariant must check the exact executable"
   [[ "$(grep -c '^      command -v gpg >/dev/null 2>&1 ||$' "${config}")" -eq 10 ]] ||
     fail "every GPG installer rule must skip when gpg already exists"
+  [[ "$(grep -c '^  - name: GPG is available$' "${config}")" -eq 1 ]] ||
+    fail "GPG configuration must finish with an availability invariant"
   [[ "$(grep -c '^    fix: brew install gnupg$' "${config}")" -eq 1 ]] ||
     fail "Homebrew GPG repair must be non-interactive"
   [[ "$(grep -c '^    interactive-fix: |$' "${config}")" -eq 9 ]] ||
@@ -255,6 +261,8 @@ apk apk gnupg run_privileged apk add gnupg
 xbps-install xbps-install gnupg2 run_privileged xbps-install -Sy gnupg2
 pkg pkg gnupg run_privileged pkg install -y gnupg
 GPG_MANAGERS
+
+  "${SNAPSHOT}/tests/stow-rulesy-contract.sh" "${SNAPSHOT}"
 }
 
 run_default_rulesy_failure_test() {
@@ -437,6 +445,7 @@ run_bootstrap_test
 run_rulesy_install_test
 run_default_rulesy_contract_test
 run_default_rulesy_failure_test
+"${SNAPSHOT}/tests/home-files-helper-integration.sh" "${SNAPSHOT}"
 run_hostname_derivation_test
 run_rulesy_shell_safety_test
 run_normal_home_test

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -3,6 +3,7 @@ set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+RULESY_BIN="${RULESY_BIN:-$(command -v rulesy || true)}"
 
 usage() {
   cat <<EOF
@@ -58,6 +59,8 @@ run_case() {
   tag="$(image_tag_for "${dockerfile}")"
   case_name="$(basename "${dockerfile}" .Dockerfile)"
 
+  [[ -x "${RULESY_BIN}" ]] || die "Rulesy is required; set RULESY_BIN to an executable Linux Rulesy binary"
+
   echo "[tests/run.sh] Building ${tag} from ${dockerfile}"
   docker build --file "${dockerfile}" --tag "${tag}" "${REPO_ROOT}"
 
@@ -65,6 +68,8 @@ run_case() {
   docker run --rm \
     --env HOME=/tmp/test-home \
     --mount "type=bind,src=${REPO_ROOT},dst=/workspace/dotfiles,readonly" \
+    --mount "type=bind,src=${RULESY_BIN},dst=/usr/local/bin/rulesy-test,readonly" \
+    --env RULESY_TEST_BIN=/usr/local/bin/rulesy-test \
     --workdir /workspace/dotfiles \
     --tmpfs /tmp:rw,nosuid,nodev,mode=1777 \
     --env TEST_CASE_NAME="${case_name}" \
@@ -148,7 +153,10 @@ run_case() {
         local home="$1"
 
         mkdir -p "${home}/bin" "${home}/.dof/bin"
-        : >"${home}/bin/rulesy"
+        cat >"${home}/bin/rulesy" <<'RULESY'
+#!/bin/sh
+exec "${RULESY_TEST_BIN}" "$@"
+RULESY
         chmod 0755 "${home}/bin/rulesy"
         cp ./tests/support/fake-dof.sh "${home}/.dof/bin/dof"
         chmod 0755 "${home}/.dof/bin/dof"
@@ -232,6 +240,9 @@ run_case() {
         seed_rulesy "${HOME}"
         expect_pass "syntax: install.sh" bash -n ./install.sh
         expect_pass "syntax: features/default/apply" bash -n ./features/default/apply
+        expect_pass "syntax: shared home-files helper" \
+          bash -n ./features/default/scripts/stow-home-files
+        expect_pass "contract: Stow Rulesy" ./tests/stow-rulesy-contract.sh .
         expect_pass "syntax: features/hostname/apply" bash -n ./features/hostname/apply
         expect_pass "syntax: features/hostname/desired-hostname" \
           bash -n ./features/hostname/desired-hostname
@@ -305,6 +316,9 @@ run_case() {
         seed_rulesy "${HOME}"
         expect_pass "syntax: install.sh" bash -n ./install.sh
         expect_pass "syntax: features/default/apply" bash -n ./features/default/apply
+        expect_pass "syntax: shared home-files helper" \
+          bash -n ./features/default/scripts/stow-home-files
+        expect_pass "contract: Stow Rulesy" ./tests/stow-rulesy-contract.sh .
         expect_pass "syntax: features/hostname/apply" bash -n ./features/hostname/apply
         expect_pass "syntax: features/hostname/desired-hostname" \
           bash -n ./features/hostname/desired-hostname

--- a/tests/stow-rulesy-contract.sh
+++ b/tests/stow-rulesy-contract.sh
@@ -1,0 +1,106 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+REPO_ROOT="${1:-$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)}"
+CONFIG="${REPO_ROOT}/features/default/stow.rulesy.yaml"
+HOME_CONFIG="${REPO_ROOT}/features/default/home-files.rulesy.yaml"
+MAIN_CONFIG="${REPO_ROOT}/features/default/rulesy.yaml"
+APPLY_HOOK="${REPO_ROOT}/features/default/apply"
+HELPER="${REPO_ROOT}/features/default/scripts/stow-home-files"
+
+fail() {
+  printf '[tests/stow-rulesy-contract.sh] %s\n' "$*" >&2
+  exit 1
+}
+
+rule_block() {
+  local heading="$1"
+
+  awk -v heading="  - name: ${heading}" '
+    $0 == heading { selected = 1; next }
+    selected && /^  - name:/ { exit }
+    selected { print }
+  ' "${CONFIG}"
+}
+
+[[ "$(cat "${MAIN_CONFIG}")" == $'rules:\n  - remote: gpg.rulesy.yaml\n  - remote: stow.rulesy.yaml\n  - remote: home-files.rulesy.yaml' ]] ||
+  fail "default rulesy.yaml must contain only the ordered GPG, Stow, and home-files remotes"
+
+[[ "$(cat "${HOME_CONFIG}")" == $'rules:\n  - name: Home files are linked from the active dof workspace\n    skip-if: |\n      ! command -v gpg >/dev/null 2>&1 ||\n        ! command -v stow >/dev/null 2>&1\n    check: ./scripts/stow-home-files check\n    fix: ./scripts/stow-home-files apply' ]] ||
+  fail "home-files.rulesy.yaml does not have the expected guarded helper lifecycle"
+
+if grep -Eiq '\bstow\b' "${APPLY_HOOK}"; then
+  fail "features/default/apply must not contain direct Stow behavior"
+fi
+
+[[ -x "${HELPER}" ]] || fail "the shared Stow home-files helper must be executable"
+grep -Fq -- '--simulate' "${HELPER}" || fail "helper check must simulate"
+grep -Fq -- '--stow' "${HELPER}" || fail "helper check must use the stow action"
+grep -Fq -- '--restow' "${HELPER}" || fail "helper apply must restow"
+grep -Fq -- '--delete' "${HELPER}" || fail "helper must support safe deletion"
+if grep -Fq -- '--adopt' "${HELPER}"; then
+  fail "helper must never adopt unmanaged files"
+fi
+
+[[ "$(grep -c '^  - name: GNU Stow is installed with ' "${CONFIG}")" -eq 19 ]] ||
+  fail "Stow configuration must contain Homebrew plus root/sudo rules for nine system managers"
+[[ "$(grep -c '^    check: command -v stow >/dev/null 2>&1$' "${CONFIG}")" -eq 20 ]] ||
+  fail "every Stow installer and the final invariant must check the exact executable"
+[[ "$(grep -c '^      command -v stow >/dev/null 2>&1 ||$' "${CONFIG}")" -eq 19 ]] ||
+  fail "every installer rule must skip when Stow already exists"
+[[ "$(grep -c '^    fix: brew install stow$' "${CONFIG}")" -eq 1 ]] ||
+  fail "Homebrew Stow repair must be an ordinary fix"
+[[ "$(grep -c '^    interactive-fix: |$' "${CONFIG}")" -eq 9 ]] ||
+  fail "every non-root system-manager repair must be interactive"
+[[ "$(grep -c '^  - name: GNU Stow is available$' "${CONFIG}")" -eq 1 ]] ||
+  fail "Stow configuration must finish with an availability invariant"
+
+previous_line=0
+prior_managers=()
+while IFS='|' read -r label manager install_command; do
+  root_heading="GNU Stow is installed with ${label} as root"
+  sudo_heading="GNU Stow is installed with ${label} using sudo"
+  root_line="$(grep -nFx "  - name: ${root_heading}" "${CONFIG}" | cut -d: -f1)"
+  sudo_line="$(grep -nFx "  - name: ${sudo_heading}" "${CONFIG}" | cut -d: -f1)"
+
+  [[ -n "${root_line}" && -n "${sudo_line}" && "${root_line}" -gt "${previous_line}" &&
+    "${sudo_line}" -gt "${root_line}" ]] ||
+    fail "Stow manager precedence or root/sudo ordering is incorrect at ${manager}"
+  previous_line="${sudo_line}"
+
+  root="$(rule_block "${root_heading}")"
+  sudo="$(rule_block "${sudo_heading}")"
+
+  grep -Fq "! command -v ${manager} >/dev/null 2>&1" <<<"${root}" ||
+    fail "root rule for ${manager} does not skip when the manager is absent"
+  grep -Fq "! command -v ${manager} >/dev/null 2>&1" <<<"${sudo}" ||
+    fail "sudo rule for ${manager} does not skip when the manager is absent"
+  grep -Fq '[[ "${EUID:-$(id -u)}" -ne 0 ]]' <<<"${root}" ||
+    fail "root rule for ${manager} is not restricted to root"
+  grep -Fq '[[ "${EUID:-$(id -u)}" -eq 0 ]]' <<<"${sudo}" ||
+    fail "sudo rule for ${manager} is not restricted to non-root users"
+  grep -Fq "${install_command}" <<<"${root}" ||
+    fail "root rule for ${manager} has the wrong install command"
+  grep -Fq "sudo ${install_command}" <<<"${sudo}" ||
+    fail "sudo rule for ${manager} has the wrong install command"
+
+  for higher_manager in "${prior_managers[@]}"; do
+    grep -Fq "command -v ${higher_manager} >/dev/null 2>&1 ||" <<<"${root}" ||
+      fail "root rule for ${manager} does not defer to ${higher_manager}"
+    grep -Fq "command -v ${higher_manager} >/dev/null 2>&1 ||" <<<"${sudo}" ||
+      fail "sudo rule for ${manager} does not defer to ${higher_manager}"
+  done
+  prior_managers+=("${manager}")
+done <<'MANAGERS'
+apt-get|apt-get|apt-get install -y stow
+apt|apt|apt install -y stow
+dnf|dnf|dnf install -y stow
+yum|yum|yum install -y stow
+pacman|pacman|pacman -Sy --noconfirm stow
+zypper|zypper|zypper --non-interactive install stow
+apk|apk|apk add stow
+xbps-install|xbps-install|xbps-install -Sy stow
+pkg|pkg|pkg install -y stow
+MANAGERS
+
+printf '[tests/stow-rulesy-contract.sh] Stow Rulesy contract passed.\n'

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -58,12 +58,18 @@ if [[ -n "${ACCOUNT_HOME}" && "${HOME}" != "${ACCOUNT_HOME}" ]]; then
 fi
 
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-DOTFILES_SOURCE_PATH="${REPO_ROOT}/home"
-CODEX_SOURCE_PATH="${DOTFILES_SOURCE_PATH}/.codex"
+HOME_PAYLOAD_PATH="${REPO_ROOT}/home"
+HOME_FILES_HELPER="${REPO_ROOT}/features/default/scripts/stow-home-files"
+CODEX_SOURCE_PATH="${HOME_PAYLOAD_PATH}/.codex"
 CODEX_TARGET_PATH="${HOME}/.codex"
 
-if [[ ! -d "${DOTFILES_SOURCE_PATH}" ]]; then
-  log "Expected Stow package directory '${DOTFILES_SOURCE_PATH}' does not exist." >&2
+if [[ ! -d "${HOME_PAYLOAD_PATH}" ]]; then
+  log "Expected home payload directory '${HOME_PAYLOAD_PATH}' does not exist." >&2
+  exit 1
+fi
+
+if [[ ! -x "${HOME_FILES_HELPER}" ]]; then
+  log "Expected home-files helper '${HOME_FILES_HELPER}' is not executable." >&2
   exit 1
 fi
 
@@ -87,29 +93,7 @@ unlink_codex_config() {
   log "Removed Codex config link: ${target_file}"
 }
 
-if ! command -v stow >/dev/null 2>&1; then
-  log "GNU Stow is not installed. Cannot remove Stow-managed symlinks." >&2
-  log "Install GNU Stow first, then rerun this script." >&2
-  exit 1
-fi
-
-log "GNU Stow is installed: $(command -v stow)"
-
-STOW_PACKAGE="${DOTFILES_SOURCE_PATH#"${REPO_ROOT}/"}"
-STOW_VERBOSITY="${STOW_VERBOSITY:-${VERBOCITY:-2}}"
-STOW_COMMAND=(
-  stow
-  "--verbose=${STOW_VERBOSITY}"
-  --delete
-  --dir "${REPO_ROOT}"
-  --target "${HOME}"
-  "${STOW_PACKAGE}"
-)
-
 unlink_codex_config
-log "Removing links from '${DOTFILES_SOURCE_PATH}' in '${HOME}'..."
-printf -v STOW_COMMAND_DISPLAY "%q " "${STOW_COMMAND[@]}"
-log "Running \`${STOW_COMMAND_DISPLAY% }\`..."
-prepend "[stow]" "${STOW_COMMAND[@]}"
+"${HOME_FILES_HELPER}" uninstall
 log "Dotfiles symlinks removed from '${HOME}'."
 log "GNU Stow was not uninstalled."

--- a/verify.sh
+++ b/verify.sh
@@ -11,21 +11,15 @@ on_exit() {
 
 trap on_exit EXIT
 
-prepend_text() {
-  local prefix="$1"
-
-  awk -v p="$prefix" '{ print p " " $0; fflush(); }'
-}
-
 prepend() {
   local prefix="$1"; shift
 
   if command -v stdbuf >/dev/null 2>&1; then
-    stdbuf -oL -eL "$@" 2>&1 | prepend_text "$prefix"
+    stdbuf -oL -eL "$@" 2>&1 | awk -v p="$prefix" '{ print p " " $0; fflush(); }'
   elif command -v script >/dev/null 2>&1; then
-    script -q /dev/null "$@" 2>&1 | prepend_text "$prefix"
+    script -q /dev/null "$@" 2>&1 | awk -v p="$prefix" '{ print p " " $0; fflush(); }'
   else
-    "$@" 2>&1 | prepend_text "$prefix"
+    "$@" 2>&1 | awk -v p="$prefix" '{ print p " " $0; fflush(); }'
   fi
 }
 
@@ -64,12 +58,18 @@ if [[ -n "${ACCOUNT_HOME}" && "${HOME}" != "${ACCOUNT_HOME}" ]]; then
 fi
 
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-DOTFILES_SOURCE_PATH="${REPO_ROOT}/home"
-CODEX_SOURCE_PATH="${DOTFILES_SOURCE_PATH}/.codex"
+HOME_PAYLOAD_PATH="${REPO_ROOT}/home"
+HOME_FILES_HELPER="${REPO_ROOT}/features/default/scripts/stow-home-files"
+CODEX_SOURCE_PATH="${HOME_PAYLOAD_PATH}/.codex"
 CODEX_TARGET_PATH="${HOME}/.codex"
 
-if [[ ! -d "${DOTFILES_SOURCE_PATH}" ]]; then
-  log "Expected Stow package directory '${DOTFILES_SOURCE_PATH}' does not exist." >&2
+if [[ ! -d "${HOME_PAYLOAD_PATH}" ]]; then
+  log "Expected home payload directory '${HOME_PAYLOAD_PATH}' does not exist." >&2
+  exit 1
+fi
+
+if [[ ! -x "${HOME_FILES_HELPER}" ]]; then
+  log "Expected home-files helper '${HOME_FILES_HELPER}' is not executable." >&2
   exit 1
 fi
 
@@ -97,51 +97,9 @@ verify_codex_config() {
   log "Codex config is correctly linked: ${target_file}"
 }
 
-if ! command -v stow >/dev/null 2>&1; then
-  log "GNU Stow is not installed. Cannot verify Stow-managed symlinks." >&2
-  log "Run '${HOME}/.dof/bin/dof apply' first." >&2
-  exit 1
-fi
-
-log "GNU Stow is installed: $(command -v stow)"
-
-STOW_PACKAGE="${DOTFILES_SOURCE_PATH#"${REPO_ROOT}/"}"
-STOW_VERBOSITY="${STOW_VERBOSITY:-${VERBOCITY:-1}}"
-STOW_COMMAND=(
-  stow
-  "--verbose=${STOW_VERBOSITY}"
-  --simulate
-  --stow
-  --dir "${REPO_ROOT}"
-  --target "${HOME}"
-  "${STOW_PACKAGE}"
-)
-
-log "Verifying links from '${DOTFILES_SOURCE_PATH}' in '${HOME}'..."
-printf -v STOW_COMMAND_DISPLAY "%q " "${STOW_COMMAND[@]}"
-log "Running \`${STOW_COMMAND_DISPLAY% }\`..."
-
-set +e
-STOW_OUTPUT="$("${STOW_COMMAND[@]}" 2>&1)"
-STOW_STATUS="$?"
-set -e
-
-if [[ -n "${STOW_OUTPUT}" ]]; then
-  printf '%s\n' "${STOW_OUTPUT}" | prepend_text "[stow]"
-fi
-
-if [[ "${STOW_STATUS}" -ne 0 ]]; then
-  log "Stow reported an error while verifying dotfiles." >&2
-  exit "${STOW_STATUS}"
-fi
-
-STOW_ACTION_OUTPUT="$(
-  printf '%s\n' "${STOW_OUTPUT}" | awk '$0 != "WARNING: in simulation mode so not modifying filesystem."'
-)"
-
-if [[ -n "${STOW_ACTION_OUTPUT}" ]]; then
-  log "Dotfiles are not fully linked. The simulated Stow run above shows pending changes." >&2
-  log "Run '${HOME}/.dof/bin/dof apply' to apply them." >&2
+log "Verifying managed home links in '${HOME}'..."
+if ! "${HOME_FILES_HELPER}" check; then
+  log "Home files are not fully linked. Run '${HOME}/.dof/bin/dof apply' to apply them." >&2
   exit 1
 fi
 


### PR DESCRIPTION
## Summary

- move GNU Stow installation and package-manager selection into ordered Rulesy remotes
- reconcile the complete `home/` package through a shared safety-focused helper used by Rulesy, verification, and uninstall
- remove direct Stow logic from `features/default/apply` while preserving initial-file backups and special Codex linking
- add contract and isolated-home integration coverage for installation, drift repair, legacy handoff, conflicts, and removal

## Why

Rulesy is now installed reliably enough to own the transitional GNU Stow lifecycle. Centralizing Stow checks, fixes, legacy-checkout handoff, and uninstall behavior removes duplicated shell logic while retaining the existing Stow payload and safety guarantees.

The shared helper derives its repository and target paths internally, never uses `--adopt`, and rejects ambiguous legacy ownership or unmanaged conflicts without deleting targets.

## Notable behavior

- the default Rulesy configuration runs GPG, Stow, then home-file reconciliation in dependency order
- supported package-manager precedence is preserved across Homebrew, apt, dnf/yum, pacman, zypper, apk, xbps, and pkg
- `verify.sh` and `uninstall.sh` delegate Stow lifecycle behavior to the same helper
- copied initial files and the special Codex config link remain outside Stow ownership
- a final GPG availability invariant prevents later mutations when the prerequisite could not be installed

## Validation

- shell syntax checks passed for affected entry points and test scripts
- `dof` v0.1.7 lint passed
- Rulesy v0.8.3 configuration execution passed in isolated homes
- `tests/integration.sh` passed with real dof and Rulesy binaries
- `tests/stow-rulesy-contract.sh .` passed
- `tests/home-files-helper-integration.sh .` passed
- `git diff --check` passed
- `tests/run.sh --all` reached and passed its integration phase, but the Docker package-manager matrix could not run because Docker is unavailable in this environment (`docker: command not found`)
