### PR TITLE
Make macOS GUI setup opt-in

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -22,8 +22,10 @@ copied as regular files.
 
 ## Lifecycle
 
-- `./install.sh` bootstraps `$HOME/.dof/bin/dof`, clones this repository, and
-  runs `dof apply`.
+- `./install.sh` bootstraps `$HOME/.dof/bin/dof`, clones this repository,
+  explicitly disables `macos-gui` for a fresh dof state, and runs `dof apply`.
+  Installer reruns preserve the existing feature selection; users opt in with
+  `dof feature enable macos-gui`.
 - `features/default/apply` is the idempotent feature hook and underlying
   installer. After installing Rulesy, it runs the default Rulesy configuration
   with fixes enabled before copying initial files or linking Codex config.

--- a/README.md
+++ b/README.md
@@ -13,6 +13,13 @@ machine, with Homebrew preferred before the supported system managers. A
 missing prerequisite fails before home links, copied initial files, or the
 Codex link are changed. This remains post-bootstrap maintenance: dof's own
 installer must still be able to complete before the default feature can run.
+Fresh installs leave `macos-gui` disabled so bootstrap does not install apps or
+change GUI preferences implicitly. Enable it explicitly, then apply:
+
+```sh
+"$HOME/.dof/bin/dof" feature enable macos-gui
+"$HOME/.dof/bin/dof" apply
+```
 
 The `macos-gui` feature uses Rulesy to install Homebrew, append its desired
 formula, casks, and App Store entries to `$HOME/.Brewfile`, and reconcile them

--- a/install.sh
+++ b/install.sh
@@ -18,6 +18,14 @@ if [[ ! -d "${HOME}" ]]; then
 fi
 
 DOF_BIN="${HOME}/.dof/bin/dof"
+DOF_CONFIG_PATH="${HOME}/.dof/config.yaml"
+DOF_WORKSPACE_PATH="${HOME}/.dof/workspace"
+FRESH_DOF_STATE=0
+
+if [[ ! -e "${DOF_CONFIG_PATH}" && ! -L "${DOF_CONFIG_PATH}" &&
+  ! -e "${DOF_WORKSPACE_PATH}" && ! -L "${DOF_WORKSPACE_PATH}" ]]; then
+  FRESH_DOF_STATE=1
+fi
 
 if [[ ! -x "${DOF_BIN}" ]]; then
   printf '[install.sh] Installing dof into %s...\n' "${HOME}/.dof/bin"
@@ -32,7 +40,12 @@ fi
 printf '[install.sh] Installing dotfiles workspace from %s...\n' "${DOTFILES_REPOSITORY}"
 "${DOF_BIN}" clone "${DOTFILES_REPOSITORY}"
 
-printf '[install.sh] Applying the default dotfiles feature...\n'
+if [[ "${FRESH_DOF_STATE}" -eq 1 ]]; then
+  printf '[install.sh] Leaving the macos-gui feature disabled until explicitly enabled...\n'
+  "${DOF_BIN}" feature disable macos-gui
+fi
+
+printf '[install.sh] Applying enabled dotfiles features...\n'
 "${DOF_BIN}" apply
 
 printf '[install.sh] Dotfiles installation completed successfully.\n'

--- a/tests/integration.sh
+++ b/tests/integration.sh
@@ -88,6 +88,10 @@ mkdir -p "$DEST"
 cat >"$DEST/dof" <<'DOF'
 #!/bin/sh
 printf '%s\n' "$*" >>"$HOME/dof-calls"
+if [ "$1" = clone ]; then
+  mkdir -p "$HOME/.dof/workspace"
+  : >"$HOME/.dof/config.yaml"
+fi
 DOF
 chmod 0755 "$DEST/dof"
 INSTALLER
@@ -98,8 +102,10 @@ CURL
   [[ -x "${home}/.dof/bin/dof" ]] || fail "bootstrap did not install the home-local dof binary"
   [[ "$(sed -n '1p' "${home}/dof-calls")" == "clone https://github.com/notwillk/dotfiles.git" ]] ||
     fail "bootstrap did not clone the expected repository first"
-  [[ "$(sed -n '2p' "${home}/dof-calls")" == "apply" ]] ||
-    fail "bootstrap did not apply after clone"
+  [[ "$(sed -n '2p' "${home}/dof-calls")" == "feature disable macos-gui" ]] ||
+    fail "fresh bootstrap did not disable the opt-in macos-gui feature"
+  [[ "$(sed -n '3p' "${home}/dof-calls")" == "apply" ]] ||
+    fail "bootstrap did not apply after selecting fresh-install features"
 
   cat >"${fake_bin}/curl" <<'CURL'
 #!/bin/sh
@@ -107,8 +113,13 @@ printf 'curl must not run when the requested dof binary exists\n' >&2
 exit 99
 CURL
   HOME="${home}" PATH="${fake_bin}:${PATH}" "${REPO_ROOT}/install.sh"
-  [[ "$(wc -l <"${home}/dof-calls")" -eq 4 ]] ||
-    fail "bootstrap rerun did not invoke clone and apply exactly once"
+  [[ "$(wc -l <"${home}/dof-calls")" -eq 5 ]] ||
+    fail "bootstrap rerun did not invoke only clone and apply"
+  [[ "$(sed -n '4p' "${home}/dof-calls")" == "clone https://github.com/notwillk/dotfiles.git" &&
+    "$(sed -n '5p' "${home}/dof-calls")" == "apply" ]] ||
+    fail "bootstrap rerun did not preserve the existing feature selection"
+  [[ "$(grep -cFx 'feature disable macos-gui' "${home}/dof-calls")" -eq 1 ]] ||
+    fail "bootstrap rerun changed the macos-gui feature selection"
 
   local failure_home="${TEST_ROOT}/bootstrap-failure-home"
   mkdir -p "${failure_home}/.dof/bin"


### PR DESCRIPTION
## Summary

- explicitly disable `macos-gui` during a genuinely fresh dotfiles bootstrap
- preserve the existing feature selection on installer reruns, including an explicit `true`
- document the opt-in enable/apply commands
- cover first-install and rerun command ordering in isolated-home integration tests

## Root cause

`install.sh` ran an unrestricted `dof apply` immediately after clone. Dof treats an omitted feature setting as enabled, so the newly discovered `macos-gui` feature ran even though the user had never opted into it. The installer log also incorrectly claimed only the default feature was being applied.

## Impact

Fresh installs now write `macos-gui: false` through `dof feature disable macos-gui` before the first apply. Existing dof state is never overwritten, so users who explicitly enable the feature keep it enabled on future installer runs.

## Validation

- `bash -n install.sh tests/integration.sh`
- `dof` v0.1.7 lint
- full isolated-home `tests/integration.sh`
- `git diff --check`

The Docker matrix was not run because Docker is unavailable in this environment.
