### PR TITLE
Fix macOS hostname detection SIGPIPE

### DIFF
--- a/features/hostname/desired-hostname
+++ b/features/hostname/desired-hostname
@@ -10,7 +10,7 @@ fail() {
 
 marketing_name="$(
   ioreg -l -r -c IOPlatformDevice 2>/dev/null |
-    awk -F '"' '/"product-name"[[:space:]]*=/ { print $4; exit }'
+    awk -F '"' '!found && /"product-name"[[:space:]]*=/ { print $4; found = 1 }'
 )"
 [[ -n "${marketing_name}" ]] || fail "could not determine the Mac marketing model name"
 

--- a/tests/integration.sh
+++ b/tests/integration.sh
@@ -345,6 +345,9 @@ UNAME
   cat >"${fake_bin}/ioreg" <<'IOREG'
 #!/bin/sh
 printf '    "product-name" = <"%s">\n' "${FAKE_MARKETING_NAME}"
+if [ "${FAKE_IOREG_PADDING:-0}" = 1 ]; then
+  awk 'BEGIN { for (i = 0; i < 50000; i++) print "padding" }'
+fi
 IOREG
   cat >"${fake_bin}/system_profiler" <<'SYSTEM_PROFILER'
 #!/bin/sh
@@ -352,10 +355,16 @@ printf '      Chip: %s\n' "${FAKE_CHIP_NAME}"
 SYSTEM_PROFILER
   chmod 0755 "${fake_bin}/uname" "${fake_bin}/ioreg" "${fake_bin}/system_profiler"
 
+  [[ "$(grep -c "^    interactive-fix: |$" "${SNAPSHOT}/features/hostname/rulesy.yaml")" -eq 1 ]] ||
+    fail "hostname repair must remain an interactive Rulesy fix"
+  grep -Fqx "      sudo -v" "${SNAPSHOT}/features/hostname/rulesy.yaml" ||
+    fail "hostname repair must authenticate with sudo interactively"
+
   local actual
   actual="$(
     FAKE_MARKETING_NAME='MacBook Pro (14-inch, Nov 2024)' \
       FAKE_CHIP_NAME='Apple M4 Pro' \
+      FAKE_IOREG_PADDING=1 \
       PATH="${fake_bin}:${PATH}" \
       "${SNAPSHOT}/features/hostname/desired-hostname"
   )"


### PR DESCRIPTION
## What changed

- keep reading `ioreg` output after capturing the first product name so the producer does not receive SIGPIPE
- add a high-volume `ioreg` regression fixture that reproduces exit 141 under `pipefail`
- lock the hostname repair contract as an interactive fix with `sudo -v`

## Why

`desired-hostname` previously exited its `awk` consumer immediately after finding `product-name`. With `set -o pipefail`, that could close the pipe while `ioreg` was still writing, causing `ioreg` and the hostname rule to exit with status 141.

The repair already uses Rulesy `interactive-fix`, which is required because changing macOS hostnames invokes `sudo`.

## User impact

Enabled hostname reconciliation can now derive the Mac hostname without the false exit-141 failure, while still allowing interactive sudo authentication when a hostname change is required.

## Validation

- reproduced status 141 with a high-volume fake `ioreg` before the fix
- confirmed the same reproduction returns `mbp-m4p-2024` after the fix
- shell syntax checks
- `dof lint .`
- isolated custom-`$HOME` integration suite
- `git diff --check`

Docker is unavailable in the development environment, so the Docker matrix was not run.